### PR TITLE
fix: add cli-proxy image to Docker pre-download list

### DIFF
--- a/pkg/workflow/docker.go
+++ b/pkg/workflow/docker.go
@@ -99,6 +99,18 @@ func collectDockerImages(tools map[string]any, workflowData *WorkflowData, actio
 				dockerLog.Printf("Added AWF api-proxy sidecar container: %s", apiProxyImage)
 			}
 		}
+
+		// Add cli-proxy sidecar container when the cli-proxy feature flag is enabled
+		// and the AWF version supports it. Without this, --skip-pull causes AWF to fail
+		// because the cli-proxy image was never pulled.
+		if isFeatureEnabled(constants.CliProxyFeatureFlag, workflowData) && awfSupportsCliProxy(firewallConfig) {
+			cliProxyImage := constants.DefaultFirewallRegistry + "/cli-proxy:" + awfImageTag
+			if !imageSet[cliProxyImage] {
+				images = append(images, cliProxyImage)
+				imageSet[cliProxyImage] = true
+				dockerLog.Printf("Added AWF cli-proxy sidecar container: %s", cliProxyImage)
+			}
+		}
 	}
 
 	// Collect sandbox.mcp container (MCP gateway)

--- a/pkg/workflow/docker_cli_proxy_test.go
+++ b/pkg/workflow/docker_cli_proxy_test.go
@@ -1,0 +1,93 @@
+package workflow
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/github/gh-aw/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectDockerImages_CliProxy(t *testing.T) {
+	// Use a version without "v" prefix — getAWFImageTag strips it
+	awfImageTag := "0.25.18"
+
+	t.Run("includes cli-proxy image when feature flag is enabled", func(t *testing.T) {
+		workflowData := &WorkflowData{
+			AI: "claude",
+			NetworkPermissions: &NetworkPermissions{
+				Firewall: &FirewallConfig{
+					Enabled: true,
+					Version: awfImageTag,
+				},
+			},
+			Features: map[string]any{"cli-proxy": true},
+		}
+
+		images := collectDockerImages(nil, workflowData, ActionModeRelease)
+
+		cliProxyImage := constants.DefaultFirewallRegistry + "/cli-proxy:" + awfImageTag
+		assert.True(t, slices.Contains(images, cliProxyImage),
+			"Expected cli-proxy image %q in collected images, got: %v", cliProxyImage, images)
+	})
+
+	t.Run("excludes cli-proxy image when feature flag is absent", func(t *testing.T) {
+		workflowData := &WorkflowData{
+			AI: "claude",
+			NetworkPermissions: &NetworkPermissions{
+				Firewall: &FirewallConfig{
+					Enabled: true,
+					Version: awfImageTag,
+				},
+			},
+		}
+
+		images := collectDockerImages(nil, workflowData, ActionModeRelease)
+
+		cliProxyImage := constants.DefaultFirewallRegistry + "/cli-proxy:" + awfImageTag
+		assert.False(t, slices.Contains(images, cliProxyImage),
+			"Did not expect cli-proxy image %q in collected images without feature flag, got: %v", cliProxyImage, images)
+	})
+
+	t.Run("excludes cli-proxy image when AWF version is too old", func(t *testing.T) {
+		workflowData := &WorkflowData{
+			AI: "claude",
+			NetworkPermissions: &NetworkPermissions{
+				Firewall: &FirewallConfig{
+					Enabled: true,
+					Version: "v0.25.16", // older than AWFCliProxyMinVersion
+				},
+			},
+			Features: map[string]any{"cli-proxy": true},
+		}
+
+		images := collectDockerImages(nil, workflowData, ActionModeRelease)
+
+		// Should not include cli-proxy for an old AWF version
+		for _, img := range images {
+			assert.NotContains(t, img, "/cli-proxy:",
+				"Should not include cli-proxy image when AWF version is too old")
+		}
+	})
+
+	t.Run("cli-proxy image uses correct AWF image tag", func(t *testing.T) {
+		customTag := "0.26.0"
+		workflowData := &WorkflowData{
+			AI: "copilot",
+			NetworkPermissions: &NetworkPermissions{
+				Firewall: &FirewallConfig{
+					Enabled: true,
+					Version: customTag,
+				},
+			},
+			Features: map[string]any{"cli-proxy": true},
+		}
+
+		images := collectDockerImages(nil, workflowData, ActionModeRelease)
+
+		expectedImage := constants.DefaultFirewallRegistry + "/cli-proxy:" + customTag
+		require.True(t, slices.Contains(images, expectedImage),
+			"Expected cli-proxy image %q with custom tag, got: %v", expectedImage, images)
+	})
+}


### PR DESCRIPTION
## Summary

When `features: cli-proxy: true` is set, the compiler generates `--skip-pull` for AWF but does not include the `cli-proxy` image in the `download_docker_images.sh` pre-pull step. At runtime, AWF fails with:

```
No such image: ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.18
```

## Changes

- **`pkg/workflow/docker.go`**: Add `cli-proxy` image to `collectDockerImages()` when the `cli-proxy` feature flag is enabled and the AWF version supports it (`awfSupportsCliProxy`)
- **`pkg/workflow/docker_cli_proxy_test.go`**: Unit tests covering enabled/disabled/old-version/custom-tag scenarios

## Testing

All 4 new tests pass:
- `includes cli-proxy image when feature flag is enabled`
- `excludes cli-proxy image when feature flag is absent`
- `excludes cli-proxy image when AWF version is too old`
- `cli-proxy image uses correct AWF image tag`

Closes #25555