### PR TITLE
fix: rename --safe-update to --approve and improve safe update UX

### DIFF
--- a/cmd/gh-aw/main.go
+++ b/cmd/gh-aw/main.go
@@ -286,7 +286,7 @@ Examples:
 		failFast, _ := cmd.Flags().GetBool("fail-fast")
 		noCheckUpdate, _ := cmd.Flags().GetBool("no-check-update")
 		scheduleSeed, _ := cmd.Flags().GetString("schedule-seed")
-		approve, _ := cmd.Flags().GetBool("approve")
+		approve, _ := cmd.Flags().GetBool("approve-updates")
 		validateImages, _ := cmd.Flags().GetBool("validate-images")
 		priorManifestFile, _ := cmd.Flags().GetString("prior-manifest-file")
 		verbose, _ := cmd.Flags().GetBool("verbose")
@@ -399,7 +399,7 @@ Examples:
 		push, _ := cmd.Flags().GetBool("push")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		jsonOutput, _ := cmd.Flags().GetBool("json")
-		approveRun, _ := cmd.Flags().GetBool("approve")
+		approveRun, _ := cmd.Flags().GetBool("approve-updates")
 
 		if err := validateEngine(engineOverride); err != nil {
 			return err
@@ -694,7 +694,7 @@ Use "` + string(constants.CLIExtensionPrefix) + ` help all" to show help for all
 	compileCmd.Flags().Bool("fail-fast", false, "Stop at the first validation error instead of collecting all errors")
 	compileCmd.Flags().Bool("no-check-update", false, "Skip checking for gh-aw updates")
 	compileCmd.Flags().String("schedule-seed", "", "Override the repository slug (owner/repo) used as seed for fuzzy schedule scattering (e.g. 'github/gh-aw'). Bypasses git remote detection entirely. Use this when your git remote is not named 'origin' and you have multiple remotes configured")
-	compileCmd.Flags().Bool("approve", false, "Approve all safe update changes. When strict mode is active (the default), the compiler emits warnings for new restricted secrets or unapproved action additions/removals not present in the existing gh-aw-manifest. Use this flag to approve and skip safe update enforcement")
+	compileCmd.Flags().Bool("approve-updates", false, "Approve all safe update changes. When strict mode is active (the default), the compiler emits warnings for new restricted secrets or unapproved action additions/removals not present in the existing gh-aw-manifest. Use this flag to approve and skip safe update enforcement")
 	compileCmd.Flags().Bool("validate-images", false, "Require Docker to be available for container image validation. Without this flag, container image validation is silently skipped when Docker is not installed or the daemon is not running")
 	compileCmd.Flags().String("prior-manifest-file", "", "Path to a JSON file containing pre-cached gh-aw-manifests (map[lockFile]*GHAWManifest); used by the MCP server to supply a tamper-proof manifest baseline captured at startup")
 	if err := compileCmd.Flags().MarkHidden("prior-manifest-file"); err != nil {
@@ -735,7 +735,7 @@ Use "` + string(constants.CLIExtensionPrefix) + ` help all" to show help for all
 	runCmd.Flags().Bool("push", false, "Commit and push workflow files (including transitive imports) before running")
 	runCmd.Flags().Bool("dry-run", false, "Validate workflow without actually triggering execution on GitHub Actions")
 	runCmd.Flags().BoolP("json", "j", false, "Output results in JSON format")
-	runCmd.Flags().Bool("approve", false, "Approve all safe update changes during compilation (skip safe update enforcement)")
+	runCmd.Flags().Bool("approve-updates", false, "Approve all safe update changes during compilation (skip safe update enforcement)")
 	// Register completions for run command
 	runCmd.ValidArgsFunction = cli.CompleteWorkflowNames
 	cli.RegisterEngineFlagCompletion(runCmd)

--- a/cmd/gh-aw/main.go
+++ b/cmd/gh-aw/main.go
@@ -286,7 +286,7 @@ Examples:
 		failFast, _ := cmd.Flags().GetBool("fail-fast")
 		noCheckUpdate, _ := cmd.Flags().GetBool("no-check-update")
 		scheduleSeed, _ := cmd.Flags().GetString("schedule-seed")
-		safeUpdate, _ := cmd.Flags().GetBool("safe-update")
+		approve, _ := cmd.Flags().GetBool("approve")
 		validateImages, _ := cmd.Flags().GetBool("validate-images")
 		priorManifestFile, _ := cmd.Flags().GetString("prior-manifest-file")
 		verbose, _ := cmd.Flags().GetBool("verbose")
@@ -343,7 +343,7 @@ Examples:
 			Stats:                  stats,
 			FailFast:               failFast,
 			ScheduleSeed:           scheduleSeed,
-			SafeUpdate:             safeUpdate,
+			Approve:                approve,
 			ValidateImages:         validateImages,
 			PriorManifestFile:      priorManifestFile,
 		}
@@ -399,6 +399,7 @@ Examples:
 		push, _ := cmd.Flags().GetBool("push")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		jsonOutput, _ := cmd.Flags().GetBool("json")
+		approveRun, _ := cmd.Flags().GetBool("approve")
 
 		if err := validateEngine(engineOverride); err != nil {
 			return err
@@ -437,6 +438,7 @@ Examples:
 			Verbose:        verboseFlag,
 			DryRun:         dryRun,
 			JSON:           jsonOutput,
+			Approve:        approveRun,
 		})
 	},
 }
@@ -692,7 +694,7 @@ Use "` + string(constants.CLIExtensionPrefix) + ` help all" to show help for all
 	compileCmd.Flags().Bool("fail-fast", false, "Stop at the first validation error instead of collecting all errors")
 	compileCmd.Flags().Bool("no-check-update", false, "Skip checking for gh-aw updates")
 	compileCmd.Flags().String("schedule-seed", "", "Override the repository slug (owner/repo) used as seed for fuzzy schedule scattering (e.g. 'github/gh-aw'). Bypasses git remote detection entirely. Use this when your git remote is not named 'origin' and you have multiple remotes configured")
-	compileCmd.Flags().Bool("safe-update", false, "Force-enable safe update mode independently of strict mode. Safe update mode is normally equivalent to strict mode: it emits a warning prompt when compilations introduce new restricted secrets or unapproved action additions/removals not present in the existing gh-aw-manifest. Use this flag to enable safe update enforcement on a workflow that has strict: false in its frontmatter")
+	compileCmd.Flags().Bool("approve", false, "Approve all safe update changes. When strict mode is active (the default), the compiler emits warnings for new restricted secrets or unapproved action additions/removals not present in the existing gh-aw-manifest. Use this flag to approve and skip safe update enforcement")
 	compileCmd.Flags().Bool("validate-images", false, "Require Docker to be available for container image validation. Without this flag, container image validation is silently skipped when Docker is not installed or the daemon is not running")
 	compileCmd.Flags().String("prior-manifest-file", "", "Path to a JSON file containing pre-cached gh-aw-manifests (map[lockFile]*GHAWManifest); used by the MCP server to supply a tamper-proof manifest baseline captured at startup")
 	if err := compileCmd.Flags().MarkHidden("prior-manifest-file"); err != nil {
@@ -733,6 +735,7 @@ Use "` + string(constants.CLIExtensionPrefix) + ` help all" to show help for all
 	runCmd.Flags().Bool("push", false, "Commit and push workflow files (including transitive imports) before running")
 	runCmd.Flags().Bool("dry-run", false, "Validate workflow without actually triggering execution on GitHub Actions")
 	runCmd.Flags().BoolP("json", "j", false, "Output results in JSON format")
+	runCmd.Flags().Bool("approve", false, "Approve all safe update changes during compilation (skip safe update enforcement)")
 	// Register completions for run command
 	runCmd.ValidArgsFunction = cli.CompleteWorkflowNames
 	cli.RegisterEngineFlagCompletion(runCmd)

--- a/pkg/cli/compile_compiler_setup.go
+++ b/pkg/cli/compile_compiler_setup.go
@@ -158,9 +158,9 @@ func configureCompilerFlags(compiler *workflow.Compiler, config CompileConfig) {
 
 	// Set safe update flag: when set via CLI it force-enables safe update enforcement
 	// independently of the workflow's strict mode setting.
-	compiler.SetSafeUpdate(config.SafeUpdate)
-	if config.SafeUpdate {
-		compileCompilerSetupLog.Print("Safe update mode force-enabled via --safe-update flag: compilations introducing new restricted secrets or unapproved action additions/removals will emit a warning prompt requesting agent review and a PR security note")
+	compiler.SetApprove(config.Approve)
+	if config.Approve {
+		compileCompilerSetupLog.Print("Safe update changes approved via --approve flag: skipping safe update enforcement for new restricted secrets or unapproved action additions/removals")
 	}
 
 	// Set require docker flag: when set, container image validation fails instead of

--- a/pkg/cli/compile_compiler_setup.go
+++ b/pkg/cli/compile_compiler_setup.go
@@ -156,11 +156,11 @@ func configureCompilerFlags(compiler *workflow.Compiler, config CompileConfig) {
 		compileCompilerSetupLog.Print("Force refresh action pins enabled: will clear cache and resolve all actions from GitHub API")
 	}
 
-	// Set safe update flag: when set via CLI it force-enables safe update enforcement
-	// independently of the workflow's strict mode setting.
+	// Set safe update flag: when set via CLI it disables/skips safe update enforcement
+	// regardless of the workflow's strict mode setting.
 	compiler.SetApprove(config.Approve)
 	if config.Approve {
-		compileCompilerSetupLog.Print("Safe update changes approved via --approve flag: skipping safe update enforcement for new restricted secrets or unapproved action additions/removals")
+		compileCompilerSetupLog.Print("Safe update changes approved via --approve-updates flag: skipping safe update enforcement for new restricted secrets or unapproved action additions/removals")
 	}
 
 	// Set require docker flag: when set, container image validation fails instead of

--- a/pkg/cli/compile_config.go
+++ b/pkg/cli/compile_config.go
@@ -29,7 +29,7 @@ type CompileConfig struct {
 	Stats                  bool     // Display statistics table sorted by file size
 	FailFast               bool     // Stop at first error instead of collecting all errors
 	ScheduleSeed           string   // Override repository slug used for fuzzy schedule scattering (e.g. owner/repo)
-	SafeUpdate             bool     // Force-enable safe update mode regardless of strict mode setting. Safe update mode is normally equivalent to strict mode (active whenever strict mode is active).
+	Approve                bool     // Approve all safe update changes, skipping safe update enforcement regardless of strict mode setting.
 	ValidateImages         bool     // Require Docker to be available for container image validation (fail instead of skipping when Docker is unavailable)
 	PriorManifestFile      string   // Path to a JSON file containing pre-cached manifests (map[lockFile]*GHAWManifest) collected at MCP server startup; takes precedence over git HEAD / filesystem reads for safe update enforcement
 }

--- a/pkg/cli/compile_safe_update_integration_test.go
+++ b/pkg/cli/compile_safe_update_integration_test.go
@@ -90,11 +90,10 @@ func manifestLockFileWithSecret(secretName string) string {
 	)
 }
 
-// TestSafeUpdateWarnOnNewSecretOnFirstCompile verifies that --safe-update emits a
-// warning (not an error) when a first compilation introduces a non-GITHUB_TOKEN
-// secret and no prior manifest exists.  The compilation must succeed and the lock
-// file must be written so that the agent receives the actionable warning.
-func TestSafeUpdateWarnsOnNewSecretOnFirstCompile(t *testing.T) {
+// TestSafeUpdateFirstCompileCreatesBaseline verifies that the first compilation
+// (with no prior manifest) creates the manifest baseline silently without any
+// safe update warnings. Enforcement only kicks in on subsequent compilations.
+func TestSafeUpdateFirstCompileCreatesBaseline(t *testing.T) {
 	setup := setupIntegrationTest(t)
 	defer setup.cleanup()
 
@@ -102,28 +101,32 @@ func TestSafeUpdateWarnsOnNewSecretOnFirstCompile(t *testing.T) {
 	require.NoError(t, os.WriteFile(workflowPath, []byte(safeUpdateWorkflowWithSecret), 0o644),
 		"should write workflow file")
 
-	cmd := exec.Command(setup.binaryPath, "compile", workflowPath, "--safe-update")
+	// First compile with no prior lock file: should succeed without safe update warnings
+	// because there is no prior manifest to compare against.
+	cmd := exec.Command(setup.binaryPath, "compile", workflowPath)
 	cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
 
-	// Compilation must succeed (warning, not error)
-	assert.NoError(t, err, "compile should succeed in safe update mode (violation emits warning, not error)\nOutput:\n%s", outputStr)
-	// Warning must reference the violation and request a security review
-	assert.Contains(t, outputStr, "safe update mode", "output should mention safe update mode")
-	assert.Contains(t, outputStr, "MY_API_SECRET", "warning should name the offending secret")
-	assert.Contains(t, outputStr, "SECURITY REVIEW REQUIRED", "warning should request a security review")
-	// Lock file must still be written
+	assert.NoError(t, err, "first compile should succeed\nOutput:\n%s", outputStr)
+	// No safe update warnings on first compile (no prior manifest to compare against)
+	assert.NotContains(t, outputStr, "SECURITY REVIEW REQUIRED",
+		"first compile should not emit safe update warnings when no prior manifest exists")
+	// Lock file must be written with the manifest baseline
 	lockFilePath := filepath.Join(setup.workflowsDir, "safe-update-secret.lock.yml")
-	_, statErr := os.Stat(lockFilePath)
-	assert.NoError(t, statErr, "lock file should be written even when a safe-update warning is emitted")
-	t.Logf("Safe update correctly emitted warning for new secret.\nOutput:\n%s", outputStr)
+	lockContent, readErr := os.ReadFile(lockFilePath)
+	require.NoError(t, readErr, "should read lock file after first compile")
+	assert.Contains(t, string(lockContent), "gh-aw-manifest:",
+		"lock file should contain a gh-aw-manifest header after first compile")
+	assert.Contains(t, string(lockContent), "MY_API_SECRET",
+		"manifest should include the secret from the workflow")
+	t.Logf("First compile correctly created baseline without warnings.\nOutput:\n%s", outputStr)
 }
 
-// TestSafeUpdateWarnOnNewCustomActionOnFirstCompile verifies that --safe-update emits
-// a warning (not an error) when a first compilation introduces a non-actions/* action
-// reference and no prior manifest exists.  Compilation must succeed.
-func TestSafeUpdateWarnsOnNewCustomActionOnFirstCompile(t *testing.T) {
+// TestSafeUpdateFirstCompileCreatesBaselineForActions verifies that the first
+// compilation with a custom action and no prior manifest creates the baseline
+// silently without safe update warnings.
+func TestSafeUpdateFirstCompileCreatesBaselineForActions(t *testing.T) {
 	setup := setupIntegrationTest(t)
 	defer setup.cleanup()
 
@@ -131,33 +134,30 @@ func TestSafeUpdateWarnsOnNewCustomActionOnFirstCompile(t *testing.T) {
 	require.NoError(t, os.WriteFile(workflowPath, []byte(safeUpdateWorkflowWithCustomAction), 0o644),
 		"should write workflow file")
 
-	cmd := exec.Command(setup.binaryPath, "compile", workflowPath, "--safe-update")
+	// First compile with no prior lock file: should succeed without safe update warnings.
+	cmd := exec.Command(setup.binaryPath, "compile", workflowPath)
 	cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
 
-	// Compilation must succeed (warning, not error)
-	assert.NoError(t, err, "compile should succeed in safe update mode (violation emits warning, not error)\nOutput:\n%s", outputStr)
-	// Warning must reference the violation and request a security review
-	assert.Contains(t, outputStr, "safe update mode", "output should mention safe update mode")
-	assert.Contains(t, outputStr, "my-org/custom-action", "warning should name the offending action")
-	assert.Contains(t, outputStr, "SECURITY REVIEW REQUIRED", "warning should request a security review")
-	// Lock file must still be written
+	assert.NoError(t, err, "first compile should succeed\nOutput:\n%s", outputStr)
+	assert.NotContains(t, outputStr, "SECURITY REVIEW REQUIRED",
+		"first compile should not emit safe update warnings when no prior manifest exists")
+	// Lock file must be written
 	lockFilePath := filepath.Join(setup.workflowsDir, "safe-update-action.lock.yml")
 	_, statErr := os.Stat(lockFilePath)
-	assert.NoError(t, statErr, "lock file should be written even when a safe-update warning is emitted")
-	t.Logf("Safe update correctly emitted warning for new custom action.\nOutput:\n%s", outputStr)
+	assert.NoError(t, statErr, "lock file should be written after first compile")
+	t.Logf("First compile correctly created baseline without warnings.\nOutput:\n%s", outputStr)
 }
 
-// TestSafeUpdateAllowsKnownSecretWithPriorManifest verifies that --safe-update
-// allows a compilation when the secret is already recorded in the prior manifest
-// embedded in the existing lock file.
+// TestSafeUpdateAllowsKnownSecretWithPriorManifest verifies that safe update
+// enforcement allows a compilation when the secret is already recorded in the
+// prior manifest embedded in the existing lock file.
 //
-// The test uses a two-step approach: first compile without --safe-update to produce
-// a complete lock file with the full manifest (including engine-internal secrets and
-// actions), then compile again with --safe-update. Since nothing changed between the
-// two compilations, no new secrets or actions are introduced and the second compile
-// must succeed.
+// The test uses a two-step approach: first compile to produce a complete lock
+// file with the full manifest (including engine-internal secrets and actions),
+// then compile again. Since nothing changed between the two compilations, no
+// new secrets or actions are introduced and the second compile must succeed.
 func TestSafeUpdateAllowsKnownSecretWithPriorManifest(t *testing.T) {
 	setup := setupIntegrationTest(t)
 	defer setup.cleanup()
@@ -166,13 +166,13 @@ func TestSafeUpdateAllowsKnownSecretWithPriorManifest(t *testing.T) {
 	require.NoError(t, os.WriteFile(workflowPath, []byte(safeUpdateWorkflowWithSecret), 0o644),
 		"should write workflow file")
 
-	// Step 1: Compile without --safe-update to generate the full lock file + manifest.
+	// Step 1: Compile to generate the full lock file + manifest.
 	// (Engine-internal secrets such as COPILOT_GITHUB_TOKEN are also captured here.)
 	step1Cmd := exec.Command(setup.binaryPath, "compile", workflowPath)
 	step1Cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	step1Out, step1Err := step1Cmd.CombinedOutput()
 	require.NoError(t, step1Err,
-		"first compilation (no --safe-update) should succeed\nOutput:\n%s", string(step1Out))
+		"first compilation should succeed\nOutput:\n%s", string(step1Out))
 
 	lockFilePath := filepath.Join(setup.workflowsDir, "safe-update-known-secret.lock.yml")
 	lockContent, readErr := os.ReadFile(lockFilePath)
@@ -180,9 +180,9 @@ func TestSafeUpdateAllowsKnownSecretWithPriorManifest(t *testing.T) {
 	require.Contains(t, string(lockContent), "MY_API_SECRET",
 		"lock file manifest should include MY_API_SECRET after first compile")
 
-	// Step 2: Compile the identical workflow with --safe-update. The lock file from
-	// step 1 acts as the prior manifest. Nothing changed, so this must succeed.
-	step2Cmd := exec.Command(setup.binaryPath, "compile", workflowPath, "--safe-update")
+	// Step 2: Compile the identical workflow again. The lock file from step 1 acts
+	// as the prior manifest. Nothing changed, so this must succeed without warnings.
+	step2Cmd := exec.Command(setup.binaryPath, "compile", workflowPath)
 	step2Cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	output, err := step2Cmd.CombinedOutput()
 	outputStr := string(output)
@@ -191,14 +191,13 @@ func TestSafeUpdateAllowsKnownSecretWithPriorManifest(t *testing.T) {
 	t.Logf("Safe update correctly allowed known secret.\nOutput:\n%s", outputStr)
 }
 
-// TestSafeUpdateAllowsGitHubTokenOnFirstCompile verifies that --safe-update allows
-// a compilation that introduces no new non-GITHUB_TOKEN secrets compared to a
+// TestSafeUpdateAllowsGitHubTokenOnFirstCompile verifies that safe update enforcement
+// allows a compilation that introduces no new non-GITHUB_TOKEN secrets compared to a
 // previously recorded manifest.
 //
-// Uses a two-step approach: step 1 compiles without --safe-update to record the
-// baseline manifest (which includes engine-internal secrets in release mode); step 2
-// recompiles the same workflow with --safe-update and expects success because the
-// manifest is unchanged.
+// Uses a two-step approach: step 1 compiles to record the baseline manifest (which
+// includes engine-internal secrets in release mode); step 2 recompiles the same
+// workflow and expects success because the manifest is unchanged.
 func TestSafeUpdateAllowsGitHubTokenOnFirstCompile(t *testing.T) {
 	setup := setupIntegrationTest(t)
 	defer setup.cleanup()
@@ -212,7 +211,7 @@ func TestSafeUpdateAllowsGitHubTokenOnFirstCompile(t *testing.T) {
 	step1Cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	step1Out, step1Err := step1Cmd.CombinedOutput()
 	require.NoError(t, step1Err,
-		"first compilation (no --safe-update) should succeed\nOutput:\n%s", string(step1Out))
+		"first compilation should succeed\nOutput:\n%s", string(step1Out))
 
 	lockFilePath := filepath.Join(setup.workflowsDir, "safe-update-basic.lock.yml")
 	lockContent, readErr := os.ReadFile(lockFilePath)
@@ -220,8 +219,8 @@ func TestSafeUpdateAllowsGitHubTokenOnFirstCompile(t *testing.T) {
 	require.Contains(t, string(lockContent), "gh-aw-manifest:",
 		"lock file should contain a gh-aw-manifest header after first compile")
 
-	// Step 2: Re-compile with --safe-update. No secrets were added so this must succeed.
-	step2Cmd := exec.Command(setup.binaryPath, "compile", workflowPath, "--safe-update")
+	// Step 2: Re-compile. No secrets were added so this must succeed.
+	step2Cmd := exec.Command(setup.binaryPath, "compile", workflowPath)
 	step2Cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	output, err := step2Cmd.CombinedOutput()
 	outputStr := string(output)
@@ -237,8 +236,9 @@ func TestSafeUpdateAllowsGitHubTokenOnFirstCompile(t *testing.T) {
 }
 
 // safeUpdateWorkflowNonStrict is a minimal workflow that explicitly opts out of
-// strict mode.  Because safe update mode == strict mode, setting strict: false
-// also disables safe update enforcement, letting new secrets compile freely.
+// strict mode.  Because safe update enforcement follows strict mode, setting
+// strict: false also disables safe update enforcement, letting new secrets
+// compile freely.
 const safeUpdateWorkflowNonStrict = `---
 name: Non Strict Workflow
 on:
@@ -264,7 +264,7 @@ Workflow with strict: false, which also disables safe update enforcement.
 
 // TestSafeUpdateNoFlagAllowsNewSecret verifies that when strict mode is disabled
 // (strict: false in frontmatter) safe update enforcement is also disabled — new
-// secrets compile without any safe-update warning.
+// secrets compile without any safe update warning.
 func TestSafeUpdateNoFlagAllowsNewSecret(t *testing.T) {
 	setup := setupIntegrationTest(t)
 	defer setup.cleanup()
@@ -395,8 +395,8 @@ func TestSafeUpdateManifestIncludesImportedSecret(t *testing.T) {
 	require.NoError(t, os.WriteFile(workflowPath, []byte(safeUpdateWorkflowWithImport), 0o644),
 		"should write workflow file")
 
-	// Compile without --safe-update so we can inspect the manifest freely.
-	cmd := exec.Command(setup.binaryPath, "compile", workflowPath)
+	// Compile with --approve so we can inspect the manifest freely without safe update warnings.
+	cmd := exec.Command(setup.binaryPath, "compile", workflowPath, "--approve")
 	cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
@@ -415,10 +415,10 @@ func TestSafeUpdateManifestIncludesImportedSecret(t *testing.T) {
 	}
 }
 
-// TestSafeUpdateRejectsNewSecretFromImport verifies that --safe-update emits a warning
-// when the new secret is introduced via an imported workflow rather than directly in
-// the top-level workflow frontmatter.  Compilation must still succeed.
-func TestSafeUpdateWarnsOnNewSecretFromImport(t *testing.T) {
+// TestSafeUpdateFirstCompileCreatesBaselineForImport verifies that the first compilation
+// of a workflow that imports a shared config containing a secret creates the baseline
+// manifest silently without safe update warnings.
+func TestSafeUpdateFirstCompileCreatesBaselineForImport(t *testing.T) {
 	setup := setupIntegrationTest(t)
 	defer setup.cleanup()
 
@@ -428,32 +428,27 @@ func TestSafeUpdateWarnsOnNewSecretFromImport(t *testing.T) {
 	require.NoError(t, os.WriteFile(workflowPath, []byte(safeUpdateWorkflowWithImport), 0o644),
 		"should write workflow file")
 
-	// No prior lock file — safe update treats this as an empty manifest.
-	cmd := exec.Command(setup.binaryPath, "compile", workflowPath, "--safe-update")
+	// No prior lock file — first compile creates baseline silently.
+	cmd := exec.Command(setup.binaryPath, "compile", workflowPath)
 	cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
 
-	// Compilation must succeed (warning, not error)
 	assert.NoError(t, err,
-		"compile should succeed (violation emits warning, not error) when import introduces a new secret under --safe-update\nOutput:\n%s", outputStr)
-	assert.Contains(t, outputStr, "safe update mode",
-		"warning should mention safe update mode")
-	assert.Contains(t, outputStr, "SHARED_API_KEY",
-		"warning should name the secret that came from the import")
-	assert.Contains(t, outputStr, "SECURITY REVIEW REQUIRED",
-		"warning should request a security review")
-	t.Logf("Safe update correctly warned about secret introduced via import.\nOutput:\n%s", outputStr)
+		"first compile should succeed\nOutput:\n%s", outputStr)
+	assert.NotContains(t, outputStr, "SECURITY REVIEW REQUIRED",
+		"first compile should not emit safe update warnings when no prior manifest exists")
+	t.Logf("First compile correctly created baseline without warnings.\nOutput:\n%s", outputStr)
 }
 
-// TestSafeUpdateAllowsImportedSecretWithPriorManifest verifies that --safe-update
-// allows compilation when the secret introduced by an import is already recorded
-// in the prior lock file's gh-aw-manifest.
+// TestSafeUpdateAllowsImportedSecretWithPriorManifest verifies that safe update
+// enforcement allows compilation when the secret introduced by an import is already
+// recorded in the prior lock file's gh-aw-manifest.
 //
 // The test uses a two-step approach to avoid hard-coding the full set of
 // engine-required secrets in the prior manifest:
-//  1. Compile without --safe-update to produce a lock file with the full manifest.
-//  2. Compile again with --safe-update; the existing lock file (from step 1) acts as
+//  1. Compile to produce a lock file with the full manifest.
+//  2. Compile again; the existing lock file (from step 1) acts as
 //     the prior manifest and the compilation should succeed since no new
 //     secrets or actions are being introduced.
 func TestSafeUpdateAllowsImportedSecretWithPriorManifest(t *testing.T) {
@@ -466,12 +461,12 @@ func TestSafeUpdateAllowsImportedSecretWithPriorManifest(t *testing.T) {
 	require.NoError(t, os.WriteFile(workflowPath, []byte(safeUpdateWorkflowWithImport), 0o644),
 		"should write workflow file")
 
-	// Step 1: Compile without --safe-update to generate the lock file + manifest.
+	// Step 1: Compile to generate the lock file + manifest.
 	step1Cmd := exec.Command(setup.binaryPath, "compile", workflowPath)
 	step1Cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	step1Out, step1Err := step1Cmd.CombinedOutput()
 	require.NoError(t, step1Err,
-		"first compilation (no --safe-update) should succeed\nOutput:\n%s", string(step1Out))
+		"first compilation should succeed\nOutput:\n%s", string(step1Out))
 
 	// Verify the lock file was created and contains the manifest.
 	lockPath := filepath.Join(setup.workflowsDir, "import-approved.lock.yml")
@@ -480,15 +475,15 @@ func TestSafeUpdateAllowsImportedSecretWithPriorManifest(t *testing.T) {
 	require.Contains(t, string(lockContent), "SHARED_API_KEY",
 		"lock file manifest should include the imported secret after first compile")
 
-	// Step 2: Compile again with --safe-update. The lock file from step 1 serves
-	// as the prior manifest. No new secrets or actions are introduced so this must succeed.
-	step2Cmd := exec.Command(setup.binaryPath, "compile", workflowPath, "--safe-update")
+	// Step 2: Compile again. The lock file from step 1 serves as the prior manifest.
+	// No new secrets or actions are introduced so this must succeed.
+	step2Cmd := exec.Command(setup.binaryPath, "compile", workflowPath)
 	step2Cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	step2Out, step2Err := step2Cmd.CombinedOutput()
 	outputStr := string(step2Out)
 
 	assert.NoError(t, step2Err,
-		"second compilation (with --safe-update) should succeed when imported secret is already in the manifest\nOutput:\n%s", outputStr)
+		"second compilation should succeed when imported secret is already in the manifest\nOutput:\n%s", outputStr)
 	t.Logf("Safe update correctly allowed pre-approved imported secret.\nOutput:\n%s", outputStr)
 }
 
@@ -507,8 +502,8 @@ func TestSafeUpdateManifestIncludesTransitivelyImportedSecret(t *testing.T) {
 		os.WriteFile(workflowPath, []byte(safeUpdateWorkflowWithTransitiveImport), 0o644),
 		"should write workflow file")
 
-	// Compile without --safe-update so we can freely inspect the manifest.
-	cmd := exec.Command(setup.binaryPath, "compile", workflowPath)
+	// Compile with --approve so we can freely inspect the manifest without safe update warnings.
+	cmd := exec.Command(setup.binaryPath, "compile", workflowPath, "--approve")
 	cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
@@ -527,10 +522,8 @@ func TestSafeUpdateManifestIncludesTransitivelyImportedSecret(t *testing.T) {
 	}
 }
 
-// TestSafeUpdateRejectsTransitivelyImportedSecretOnFirstCompile verifies that
-// --safe-update emits a warning when the new secret is introduced via a transitive
-// import (A imports B, B imports C, C declares the secret).  Compilation must succeed.
-func TestSafeUpdateWarnsOnTransitivelyImportedSecretOnFirstCompile(t *testing.T) {
+// TestSafeUpdateFirstCompileCreatesBaselineForTransitiveImport verifies that\n// the first compilation of a workflow with a transitive import chain creates the\n// baseline manifest silently without safe update warnings.
+func TestSafeUpdateFirstCompileCreatesBaselineForTransitiveImport(t *testing.T) {
 	setup := setupIntegrationTest(t)
 	defer setup.cleanup()
 
@@ -541,20 +534,15 @@ func TestSafeUpdateWarnsOnTransitivelyImportedSecretOnFirstCompile(t *testing.T)
 		os.WriteFile(workflowPath, []byte(safeUpdateWorkflowWithTransitiveImport), 0o644),
 		"should write workflow file")
 
-	// No prior lock file — safe update treats this as an empty manifest.
-	cmd := exec.Command(setup.binaryPath, "compile", workflowPath, "--safe-update")
+	// No prior lock file — first compile creates baseline silently.
+	cmd := exec.Command(setup.binaryPath, "compile", workflowPath)
 	cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
 
-	// Compilation must succeed (warning, not error)
 	assert.NoError(t, err,
-		"compile should succeed (violation emits warning, not error) when a transitive import introduces a new secret under --safe-update\nOutput:\n%s", outputStr)
-	assert.Contains(t, outputStr, "safe update mode",
-		"warning should mention safe update mode")
-	assert.Contains(t, outputStr, "DEEP_NESTED_SECRET",
-		"warning should name the secret that came from the transitive import")
-	assert.Contains(t, outputStr, "SECURITY REVIEW REQUIRED",
-		"warning should request a security review")
-	t.Logf("Safe update correctly warned about secret from transitive import.\nOutput:\n%s", outputStr)
+		"first compile should succeed\nOutput:\n%s", outputStr)
+	assert.NotContains(t, outputStr, "SECURITY REVIEW REQUIRED",
+		"first compile should not emit safe update warnings when no prior manifest exists")
+	t.Logf("First compile correctly created baseline without warnings.\nOutput:\n%s", outputStr)
 }

--- a/pkg/cli/compile_safe_update_integration_test.go
+++ b/pkg/cli/compile_safe_update_integration_test.go
@@ -91,8 +91,10 @@ func manifestLockFileWithSecret(secretName string) string {
 }
 
 // TestSafeUpdateFirstCompileCreatesBaseline verifies that the first compilation
-// (with no prior manifest) creates the manifest baseline silently without any
-// safe update warnings. Enforcement only kicks in on subsequent compilations.
+// (with no prior manifest) still enforces safe update mode and emits a
+// SECURITY REVIEW REQUIRED warning so agents review newly introduced secrets.
+// The compile itself succeeds (warnings do not fail the build) and the lock file
+// written with the manifest serves as the baseline for future compilations.
 func TestSafeUpdateFirstCompileCreatesBaseline(t *testing.T) {
 	setup := setupIntegrationTest(t)
 	defer setup.cleanup()
@@ -101,17 +103,17 @@ func TestSafeUpdateFirstCompileCreatesBaseline(t *testing.T) {
 	require.NoError(t, os.WriteFile(workflowPath, []byte(safeUpdateWorkflowWithSecret), 0o644),
 		"should write workflow file")
 
-	// First compile with no prior lock file: should succeed without safe update warnings
-	// because there is no prior manifest to compare against.
+	// First compile with no prior lock file: should succeed but emit safe update
+	// warnings because the agent must review newly introduced secrets.
 	cmd := exec.Command(setup.binaryPath, "compile", workflowPath)
 	cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
 
-	assert.NoError(t, err, "first compile should succeed\nOutput:\n%s", outputStr)
-	// No safe update warnings on first compile (no prior manifest to compare against)
-	assert.NotContains(t, outputStr, "SECURITY REVIEW REQUIRED",
-		"first compile should not emit safe update warnings when no prior manifest exists")
+	assert.NoError(t, err, "first compile should succeed (warnings don't fail the build)\nOutput:\n%s", outputStr)
+	// Safe update warning must be emitted even on first compile so the agent reviews secrets.
+	assert.Contains(t, outputStr, "SECURITY REVIEW REQUIRED",
+		"first compile should emit safe update warnings so the agent reviews newly introduced secrets")
 	// Lock file must be written with the manifest baseline
 	lockFilePath := filepath.Join(setup.workflowsDir, "safe-update-secret.lock.yml")
 	lockContent, readErr := os.ReadFile(lockFilePath)
@@ -124,8 +126,9 @@ func TestSafeUpdateFirstCompileCreatesBaseline(t *testing.T) {
 }
 
 // TestSafeUpdateFirstCompileCreatesBaselineForActions verifies that the first
-// compilation with a custom action and no prior manifest creates the baseline
-// silently without safe update warnings.
+// compilation with a custom action and no prior manifest still enforces safe
+// update mode, emitting a SECURITY REVIEW REQUIRED warning. The compile succeeds
+// (warnings do not fail the build) and the new lock file serves as the baseline.
 func TestSafeUpdateFirstCompileCreatesBaselineForActions(t *testing.T) {
 	setup := setupIntegrationTest(t)
 	defer setup.cleanup()
@@ -134,20 +137,21 @@ func TestSafeUpdateFirstCompileCreatesBaselineForActions(t *testing.T) {
 	require.NoError(t, os.WriteFile(workflowPath, []byte(safeUpdateWorkflowWithCustomAction), 0o644),
 		"should write workflow file")
 
-	// First compile with no prior lock file: should succeed without safe update warnings.
+	// First compile with no prior lock file: should succeed but emit safe update
+	// warning so the agent reviews the newly introduced custom action.
 	cmd := exec.Command(setup.binaryPath, "compile", workflowPath)
 	cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
 
-	assert.NoError(t, err, "first compile should succeed\nOutput:\n%s", outputStr)
-	assert.NotContains(t, outputStr, "SECURITY REVIEW REQUIRED",
-		"first compile should not emit safe update warnings when no prior manifest exists")
+	assert.NoError(t, err, "first compile should succeed (warnings don't fail the build)\nOutput:\n%s", outputStr)
+	assert.Contains(t, outputStr, "SECURITY REVIEW REQUIRED",
+		"first compile should emit safe update warnings so the agent reviews newly introduced actions")
 	// Lock file must be written
 	lockFilePath := filepath.Join(setup.workflowsDir, "safe-update-action.lock.yml")
 	_, statErr := os.Stat(lockFilePath)
 	assert.NoError(t, statErr, "lock file should be written after first compile")
-	t.Logf("First compile correctly created baseline without warnings.\nOutput:\n%s", outputStr)
+	t.Logf("First compile correctly emitted warnings for new action.\nOutput:\n%s", outputStr)
 }
 
 // TestSafeUpdateAllowsKnownSecretWithPriorManifest verifies that safe update
@@ -416,8 +420,10 @@ func TestSafeUpdateManifestIncludesImportedSecret(t *testing.T) {
 }
 
 // TestSafeUpdateFirstCompileCreatesBaselineForImport verifies that the first compilation
-// of a workflow that imports a shared config containing a secret creates the baseline
-// manifest silently without safe update warnings.
+// of a workflow that imports a shared config containing a secret emits a
+// SECURITY REVIEW REQUIRED warning so the agent reviews newly introduced secrets.
+// The compile succeeds (warnings don't fail the build) and the lock file written
+// serves as the baseline for future compilations.
 func TestSafeUpdateFirstCompileCreatesBaselineForImport(t *testing.T) {
 	setup := setupIntegrationTest(t)
 	defer setup.cleanup()
@@ -428,17 +434,17 @@ func TestSafeUpdateFirstCompileCreatesBaselineForImport(t *testing.T) {
 	require.NoError(t, os.WriteFile(workflowPath, []byte(safeUpdateWorkflowWithImport), 0o644),
 		"should write workflow file")
 
-	// No prior lock file — first compile creates baseline silently.
+	// No prior lock file — first compile enforces safe update and emits a warning.
 	cmd := exec.Command(setup.binaryPath, "compile", workflowPath)
 	cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
 
 	assert.NoError(t, err,
-		"first compile should succeed\nOutput:\n%s", outputStr)
-	assert.NotContains(t, outputStr, "SECURITY REVIEW REQUIRED",
-		"first compile should not emit safe update warnings when no prior manifest exists")
-	t.Logf("First compile correctly created baseline without warnings.\nOutput:\n%s", outputStr)
+		"first compile should succeed (warnings don't fail the build)\nOutput:\n%s", outputStr)
+	assert.Contains(t, outputStr, "SECURITY REVIEW REQUIRED",
+		"first compile should emit safe update warnings so the agent reviews newly introduced secrets")
+	t.Logf("First compile correctly emitted warnings for imported secret.\nOutput:\n%s", outputStr)
 }
 
 // TestSafeUpdateAllowsImportedSecretWithPriorManifest verifies that safe update
@@ -522,7 +528,11 @@ func TestSafeUpdateManifestIncludesTransitivelyImportedSecret(t *testing.T) {
 	}
 }
 
-// TestSafeUpdateFirstCompileCreatesBaselineForTransitiveImport verifies that\n// the first compilation of a workflow with a transitive import chain creates the\n// baseline manifest silently without safe update warnings.
+// TestSafeUpdateFirstCompileCreatesBaselineForTransitiveImport verifies that
+// the first compilation of a workflow with a transitive import chain enforces
+// safe update mode and emits a SECURITY REVIEW REQUIRED warning. The compile
+// succeeds (warnings don't fail the build) and the new lock file serves as
+// the baseline.
 func TestSafeUpdateFirstCompileCreatesBaselineForTransitiveImport(t *testing.T) {
 	setup := setupIntegrationTest(t)
 	defer setup.cleanup()
@@ -534,15 +544,15 @@ func TestSafeUpdateFirstCompileCreatesBaselineForTransitiveImport(t *testing.T) 
 		os.WriteFile(workflowPath, []byte(safeUpdateWorkflowWithTransitiveImport), 0o644),
 		"should write workflow file")
 
-	// No prior lock file — first compile creates baseline silently.
+	// No prior lock file — first compile enforces safe update and emits a warning.
 	cmd := exec.Command(setup.binaryPath, "compile", workflowPath)
 	cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
 
 	assert.NoError(t, err,
-		"first compile should succeed\nOutput:\n%s", outputStr)
-	assert.NotContains(t, outputStr, "SECURITY REVIEW REQUIRED",
-		"first compile should not emit safe update warnings when no prior manifest exists")
-	t.Logf("First compile correctly created baseline without warnings.\nOutput:\n%s", outputStr)
+		"first compile should succeed (warnings don't fail the build)\nOutput:\n%s", outputStr)
+	assert.Contains(t, outputStr, "SECURITY REVIEW REQUIRED",
+		"first compile should emit safe update warnings so the agent reviews newly introduced secrets")
+	t.Logf("First compile correctly emitted warnings for transitively imported secret.\nOutput:\n%s", outputStr)
 }

--- a/pkg/cli/compile_safe_update_integration_test.go
+++ b/pkg/cli/compile_safe_update_integration_test.go
@@ -400,7 +400,7 @@ func TestSafeUpdateManifestIncludesImportedSecret(t *testing.T) {
 		"should write workflow file")
 
 	// Compile with --approve so we can inspect the manifest freely without safe update warnings.
-	cmd := exec.Command(setup.binaryPath, "compile", workflowPath, "--approve")
+	cmd := exec.Command(setup.binaryPath, "compile", workflowPath, "--approve-updates")
 	cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
@@ -509,7 +509,7 @@ func TestSafeUpdateManifestIncludesTransitivelyImportedSecret(t *testing.T) {
 		"should write workflow file")
 
 	// Compile with --approve so we can freely inspect the manifest without safe update warnings.
-	cmd := exec.Command(setup.binaryPath, "compile", workflowPath, "--approve")
+	cmd := exec.Command(setup.binaryPath, "compile", workflowPath, "--approve-updates")
 	cmd.Env = append(os.Environ(), "GH_AW_ACTION_MODE=release")
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)

--- a/pkg/cli/run_push.go
+++ b/pkg/cli/run_push.go
@@ -27,7 +27,7 @@ var runPushLog = logger.New("cli:run_push")
 // and the transitive closure of all imported files.
 // Note: This function always recompiles the workflow to ensure the lock file is up-to-date,
 // regardless of the frontmatter hash status.
-func collectWorkflowFiles(ctx context.Context, workflowPath string, verbose bool) ([]string, error) {
+func collectWorkflowFiles(ctx context.Context, workflowPath string, verbose bool, approve bool) ([]string, error) {
 	runPushLog.Printf("Collecting files for workflow: %s", workflowPath)
 
 	files := make(map[string]bool) // Use map to avoid duplicates
@@ -90,7 +90,7 @@ func collectWorkflowFiles(ctx context.Context, workflowPath string, verbose bool
 
 	// Always recompile (hash check is for observability only)
 	runPushLog.Printf("Always recompiling workflow: %s", absWorkflowPath)
-	if err := recompileWorkflow(ctx, absWorkflowPath, verbose); err != nil {
+	if err := recompileWorkflow(ctx, absWorkflowPath, verbose, approve); err != nil {
 		runPushLog.Printf("Failed to recompile workflow: %v", err)
 		return nil, fmt.Errorf("failed to recompile workflow: %w", err)
 	}
@@ -128,7 +128,7 @@ func collectWorkflowFiles(ctx context.Context, workflowPath string, verbose bool
 }
 
 // recompileWorkflow compiles a workflow using CompileWorkflows
-func recompileWorkflow(ctx context.Context, workflowPath string, verbose bool) error {
+func recompileWorkflow(ctx context.Context, workflowPath string, verbose bool, approve bool) error {
 	runPushLog.Printf("Recompiling workflow: %s", workflowPath)
 
 	config := CompileConfig{
@@ -144,6 +144,7 @@ func recompileWorkflow(ctx context.Context, workflowPath string, verbose bool) e
 		TrialMode:            false,
 		TrialLogicalRepoSlug: "",
 		Strict:               false,
+		Approve:              approve,
 	}
 
 	runPushLog.Printf("Compilation config: Validate=%v, NoEmit=%v", config.Validate, config.NoEmit)

--- a/pkg/cli/run_push_integration_test.go
+++ b/pkg/cli/run_push_integration_test.go
@@ -34,7 +34,7 @@ This is a test workflow without a lock file.
 	require.NoError(t, err)
 
 	// Test collecting files - should now compile the workflow and create lock file
-	files, err := collectWorkflowFiles(context.Background(), workflowPath, false)
+	files, err := collectWorkflowFiles(context.Background(), workflowPath, false, false)
 	require.NoError(t, err)
 	assert.Len(t, files, 2, "Should collect workflow .md file and auto-generate lock file")
 

--- a/pkg/cli/run_push_test.go
+++ b/pkg/cli/run_push_test.go
@@ -41,7 +41,7 @@ on: workflow_dispatch
 	require.NoError(t, err)
 
 	// Test collecting files
-	files, err := collectWorkflowFiles(context.Background(), workflowPath, false)
+	files, err := collectWorkflowFiles(context.Background(), workflowPath, false, false)
 	require.NoError(t, err)
 	assert.Len(t, files, 2, "Should collect workflow .md and .lock.yml files")
 
@@ -89,7 +89,7 @@ on: workflow_dispatch
 	require.NoError(t, err)
 
 	// Test collecting files
-	files, err := collectWorkflowFiles(context.Background(), workflowPath, false)
+	files, err := collectWorkflowFiles(context.Background(), workflowPath, false, false)
 	require.NoError(t, err)
 	assert.Len(t, files, 3, "Should collect workflow, lock, and imported files")
 
@@ -150,7 +150,7 @@ on: workflow_dispatch
 	require.NoError(t, err)
 
 	// Test collecting files
-	files, err := collectWorkflowFiles(context.Background(), workflowPath, false)
+	files, err := collectWorkflowFiles(context.Background(), workflowPath, false, false)
 	require.NoError(t, err)
 	assert.Len(t, files, 4, "Should collect workflow, lock, and all transitive imports")
 
@@ -504,7 +504,7 @@ jobs:
 	time.Sleep(100 * time.Millisecond)
 
 	// Collect workflow files (which should always trigger recompilation)
-	files, err := collectWorkflowFiles(context.Background(), workflowPath, false)
+	files, err := collectWorkflowFiles(context.Background(), workflowPath, false, false)
 	require.NoError(t, err)
 	assert.Len(t, files, 2, "Should collect workflow .md and .lock.yml files")
 

--- a/pkg/cli/run_workflow_execution.go
+++ b/pkg/cli/run_workflow_execution.go
@@ -36,6 +36,7 @@ type RunOptions struct {
 	Verbose           bool     // Enable verbose output
 	DryRun            bool     // Validate without actually triggering
 	JSON              bool     // Output results in JSON format
+	Approve           bool     // Approve safe update changes during compilation
 }
 
 // WorkflowRunResult contains the result of a single workflow run trigger for JSON output
@@ -277,7 +278,7 @@ func RunWorkflowOnGitHub(ctx context.Context, workflowIdOrName string, opts RunO
 
 		// Collect the workflow .md file, .lock.yml file, and transitive imports
 		workflowMarkdownPath := stringutil.LockFileToMarkdown(lockFilePath)
-		files, err := collectWorkflowFiles(ctx, workflowMarkdownPath, opts.Verbose)
+		files, err := collectWorkflowFiles(ctx, workflowMarkdownPath, opts.Verbose, opts.Approve)
 		if err != nil {
 			return fmt.Errorf("failed to collect workflow files: %w", err)
 		}

--- a/pkg/cli/upgrade_command.go
+++ b/pkg/cli/upgrade_command.go
@@ -75,6 +75,7 @@ Examples:
 			auditFlag, _ := cmd.Flags().GetBool("audit")
 			jsonOutput, _ := cmd.Flags().GetBool("json")
 			skipExtensionUpgrade, _ := cmd.Flags().GetBool("skip-extension-upgrade")
+			approveUpgrade, _ := cmd.Flags().GetBool("approve")
 
 			// Handle audit mode
 			if auditFlag {
@@ -87,7 +88,7 @@ Examples:
 				}
 			}
 
-			if err := runUpgradeCommand(cmd.Context(), verbose, dir, noFix, noCompile, noActions, skipExtensionUpgrade); err != nil {
+			if err := runUpgradeCommand(cmd.Context(), verbose, dir, noFix, noCompile, noActions, skipExtensionUpgrade, approveUpgrade); err != nil {
 				return err
 			}
 
@@ -110,6 +111,7 @@ Examples:
 	cmd.Flags().Bool("pr", false, "Alias for --create-pull-request")
 	_ = cmd.Flags().MarkHidden("pr") // Hide the short alias from help output
 	cmd.Flags().Bool("audit", false, "Check dependency health without performing upgrades")
+	cmd.Flags().Bool("approve", false, "Approve all safe update changes during compilation (skip safe update enforcement)")
 	cmd.Flags().Bool("skip-extension-upgrade", false, "Skip automatic extension upgrade (used internally to prevent recursion after upgrade)")
 	_ = cmd.Flags().MarkHidden("skip-extension-upgrade")
 	addJSONFlag(cmd)
@@ -140,7 +142,7 @@ func runDependencyAudit(verbose bool, jsonOutput bool) error {
 }
 
 // runUpgradeCommand executes the upgrade process
-func runUpgradeCommand(ctx context.Context, verbose bool, workflowDir string, noFix bool, noCompile bool, noActions bool, skipExtensionUpgrade bool) error {
+func runUpgradeCommand(ctx context.Context, verbose bool, workflowDir string, noFix bool, noCompile bool, noActions bool, skipExtensionUpgrade bool, approve bool) error {
 	upgradeLog.Printf("Running upgrade command: verbose=%v, workflowDir=%s, noFix=%v, noCompile=%v, noActions=%v, skipExtensionUpgrade=%v",
 		verbose, workflowDir, noFix, noCompile, noActions, skipExtensionUpgrade)
 
@@ -257,6 +259,7 @@ func runUpgradeCommand(ctx context.Context, verbose bool, workflowDir string, no
 		compiler := createAndConfigureCompiler(CompileConfig{
 			Verbose:     verbose,
 			WorkflowDir: workflowDir,
+			Approve:     approve,
 		})
 
 		// Determine workflow directory

--- a/pkg/cli/upgrade_command.go
+++ b/pkg/cli/upgrade_command.go
@@ -75,7 +75,7 @@ Examples:
 			auditFlag, _ := cmd.Flags().GetBool("audit")
 			jsonOutput, _ := cmd.Flags().GetBool("json")
 			skipExtensionUpgrade, _ := cmd.Flags().GetBool("skip-extension-upgrade")
-			approveUpgrade, _ := cmd.Flags().GetBool("approve")
+			approveUpgrade, _ := cmd.Flags().GetBool("approve-updates")
 
 			// Handle audit mode
 			if auditFlag {
@@ -111,7 +111,7 @@ Examples:
 	cmd.Flags().Bool("pr", false, "Alias for --create-pull-request")
 	_ = cmd.Flags().MarkHidden("pr") // Hide the short alias from help output
 	cmd.Flags().Bool("audit", false, "Check dependency health without performing upgrades")
-	cmd.Flags().Bool("approve", false, "Approve all safe update changes during compilation (skip safe update enforcement)")
+	cmd.Flags().Bool("approve-updates", false, "Approve all safe update changes during compilation (skip safe update enforcement)")
 	cmd.Flags().Bool("skip-extension-upgrade", false, "Skip automatic extension upgrade (used internally to prevent recursion after upgrade)")
 	_ = cmd.Flags().MarkHidden("skip-extension-upgrade")
 	addJSONFlag(cmd)

--- a/pkg/cli/upgrade_command.go
+++ b/pkg/cli/upgrade_command.go
@@ -143,8 +143,8 @@ func runDependencyAudit(verbose bool, jsonOutput bool) error {
 
 // runUpgradeCommand executes the upgrade process
 func runUpgradeCommand(ctx context.Context, verbose bool, workflowDir string, noFix bool, noCompile bool, noActions bool, skipExtensionUpgrade bool, approve bool) error {
-	upgradeLog.Printf("Running upgrade command: verbose=%v, workflowDir=%s, noFix=%v, noCompile=%v, noActions=%v, skipExtensionUpgrade=%v",
-		verbose, workflowDir, noFix, noCompile, noActions, skipExtensionUpgrade)
+	upgradeLog.Printf("Running upgrade command: verbose=%v, workflowDir=%s, noFix=%v, noCompile=%v, noActions=%v, skipExtensionUpgrade=%v, approve=%v",
+		verbose, workflowDir, noFix, noCompile, noActions, skipExtensionUpgrade, approve)
 
 	// Step 0b: Ensure gh-aw extension is on the latest version.
 	// If the extension was just upgraded, re-launch the freshly-installed binary

--- a/pkg/workflow/compiler_types.go
+++ b/pkg/workflow/compiler_types.go
@@ -57,7 +57,7 @@ type Compiler struct {
 	skipValidation          bool                     // If true, skip schema validation
 	noEmit                  bool                     // If true, validate without generating lock files
 	strictMode              bool                     // If true, enforce strict validation requirements
-	safeUpdate              bool                     // If true, enforce safe update mode (reject newly introduced secrets)
+	approve                 bool                     // If true, approve safe update changes (skip safe update enforcement)
 	trialMode               bool                     // If true, suppress safe outputs for trial mode execution
 	trialLogicalRepoSlug    string                   // If set in trial mode, the logical repository to checkout
 	refreshStopTime         bool                     // If true, regenerate stop-after times instead of preserving existing ones
@@ -163,12 +163,11 @@ func (c *Compiler) SetNoEmit(noEmit bool) {
 	c.noEmit = noEmit
 }
 
-// SetSafeUpdate configures whether to force-enable safe update mode via the CLI flag.
-// Safe update mode is normally equivalent to strict mode (active when strict mode is active).
-// This flag provides an additional override to enable safe update mode independently of
-// the strict mode setting.
-func (c *Compiler) SetSafeUpdate(safeUpdate bool) {
-	c.safeUpdate = safeUpdate
+// SetApprove configures whether to skip safe update enforcement via the CLI --approve flag.
+// When true, safe update enforcement is disabled regardless of strict mode setting,
+// approving all changes.
+func (c *Compiler) SetApprove(approve bool) {
+	c.approve = approve
 }
 
 // SetFileTracker sets the file tracker for tracking created files

--- a/pkg/workflow/compiler_types.go
+++ b/pkg/workflow/compiler_types.go
@@ -163,7 +163,7 @@ func (c *Compiler) SetNoEmit(noEmit bool) {
 	c.noEmit = noEmit
 }
 
-// SetApprove configures whether to skip safe update enforcement via the CLI --approve flag.
+// SetApprove configures whether to skip safe update enforcement via the CLI --approve-updates flag.
 // When true, safe update enforcement is disabled regardless of strict mode setting,
 // approving all changes.
 func (c *Compiler) SetApprove(approve bool) {

--- a/pkg/workflow/compiler_yaml.go
+++ b/pkg/workflow/compiler_yaml.go
@@ -37,11 +37,11 @@ func (c *Compiler) effectiveStrictMode(frontmatter map[string]any) bool {
 // effectiveSafeUpdate returns true when safe update mode should be enforced for
 // the given workflow. Safe update mode is equivalent to strict mode: it is
 // enabled whenever strict mode is active (CLI --strict flag, frontmatter
-// strict: true, or the default). It can also be force-enabled via the CLI
-// --safe-update flag independently of strict mode.
+// strict: true, or the default). It can be disabled via the CLI --approve flag
+// to approve all changes.
 func (c *Compiler) effectiveSafeUpdate(data *WorkflowData) bool {
-	if c.safeUpdate {
-		return true
+	if c.approve {
+		return false
 	}
 	return c.effectiveStrictMode(data.RawFrontmatter)
 }

--- a/pkg/workflow/compiler_yaml.go
+++ b/pkg/workflow/compiler_yaml.go
@@ -37,7 +37,7 @@ func (c *Compiler) effectiveStrictMode(frontmatter map[string]any) bool {
 // effectiveSafeUpdate returns true when safe update mode should be enforced for
 // the given workflow. Safe update mode is equivalent to strict mode: it is
 // enabled whenever strict mode is active (CLI --strict flag, frontmatter
-// strict: true, or the default). It can be disabled via the CLI --approve flag
+// strict: true, or the default). It can be disabled via the CLI --approve-updates flag
 // to approve all changes.
 func (c *Compiler) effectiveSafeUpdate(data *WorkflowData) bool {
 	if c.approve {

--- a/pkg/workflow/safe_update_enforcement.go
+++ b/pkg/workflow/safe_update_enforcement.go
@@ -213,7 +213,7 @@ func buildSafeUpdateError(secretViolations, addedActions, removedActions []strin
 		sb.WriteString(strings.Join(removedActions, "\n  - "))
 	}
 
-	sb.WriteString("\n\nRemediation options:\n  1. Use the --approve flag to allow the changes.\n  2. Revert the unapproved changes.\n  3. Use an interactive coding agent to review and approve the changes.")
+	sb.WriteString("\n\nRemediation options:\n  1. Use the --approve-updates flag to allow the changes.\n  2. Revert the unapproved changes.\n  3. Use an interactive coding agent to review and approve the changes.")
 	return fmt.Errorf("%s", sb.String())
 }
 

--- a/pkg/workflow/safe_update_enforcement.go
+++ b/pkg/workflow/safe_update_enforcement.go
@@ -51,7 +51,7 @@ func EnforceSafeUpdate(manifest *GHAWManifest, secretNames []string, actionRefs 
 		// Treat no prior manifest as an empty baseline so that newly introduced
 		// secrets and actions are flagged on first compilation as well.
 		safeUpdateLog.Print("No existing manifest found; enforcing safe update with empty baseline (new secrets/actions will be flagged)")
-		manifest = &GHAWManifest{}
+		manifest = &GHAWManifest{Version: currentGHAWManifestVersion}
 	}
 
 	secretViolations := collectSecretViolations(manifest, secretNames)

--- a/pkg/workflow/safe_update_enforcement.go
+++ b/pkg/workflow/safe_update_enforcement.go
@@ -45,11 +45,12 @@ var ghAwInternalSecrets = map[string]bool{
 // Returns a structured, actionable error when violations are found.
 func EnforceSafeUpdate(manifest *GHAWManifest, secretNames []string, actionRefs []string) error {
 	if manifest == nil {
-		// No prior lock file – treat as an empty manifest so safe-update enforcement
-		// blocks any secrets (other than GITHUB_TOKEN) and any custom actions on the
-		// first compilation, matching the principle of least privilege.
-		safeUpdateLog.Print("No existing manifest found; treating as empty manifest for safe update enforcement")
-		manifest = &GHAWManifest{Version: currentGHAWManifestVersion}
+		// No prior manifest found — either the lock file was compiled before the safe
+		// updates feature existed, or this is the very first compilation.  In both cases
+		// skip enforcement: the newly generated lock file will embed a manifest that
+		// serves as the baseline for future compilations.
+		safeUpdateLog.Print("No existing manifest found; skipping safe update enforcement (baseline will be created)")
+		return nil
 	}
 
 	secretViolations := collectSecretViolations(manifest, secretNames)
@@ -211,7 +212,7 @@ func buildSafeUpdateError(secretViolations, addedActions, removedActions []strin
 		sb.WriteString(strings.Join(removedActions, "\n  - "))
 	}
 
-	sb.WriteString("\n\nRemediation options:\n  1. Use an interactive agentic flow (e.g. Copilot CLI) to review and approve the changes.\n  2. Remove the --safe-update flag to allow the change.\n  3. Revert the unapproved changes from your workflow if they were added unintentionally.")
+	sb.WriteString("\n\nRemediation options:\n  1. Use the --approve flag to allow the changes.\n  2. Revert the unapproved changes.\n  3. Use an interactive coding agent to review and approve the changes.")
 	return fmt.Errorf("%s", sb.String())
 }
 

--- a/pkg/workflow/safe_update_enforcement.go
+++ b/pkg/workflow/safe_update_enforcement.go
@@ -31,9 +31,12 @@ var ghAwInternalSecrets = map[string]bool{
 // changes have been introduced compared to those recorded in the existing manifest.
 //
 // manifest is the gh-aw-manifest extracted from the current lock file before
-// recompilation. When nil (no lock file exists yet), it is treated as an empty
-// manifest so that all non-GITHUB_TOKEN secrets and all custom actions are rejected
-// on a first-time safe-update compilation.
+// recompilation. When nil (no lock file exists yet, or the lock file predates
+// the safe-updates feature), it is treated as an empty baseline so that all
+// non-GITHUB_TOKEN secrets and all custom actions are flagged on the very first
+// compilation. This ensures agents receive a SECURITY REVIEW REQUIRED prompt even
+// on the initial code-generation run. The newly generated lock file then embeds
+// the manifest as the baseline for future compilations.
 //
 // secretNames contains the raw names produced by CollectSecretReferences (i.e.
 // they may or may not carry the "secrets." prefix; both forms are normalized
@@ -45,12 +48,10 @@ var ghAwInternalSecrets = map[string]bool{
 // Returns a structured, actionable error when violations are found.
 func EnforceSafeUpdate(manifest *GHAWManifest, secretNames []string, actionRefs []string) error {
 	if manifest == nil {
-		// No prior manifest found — either the lock file was compiled before the safe
-		// updates feature existed, or this is the very first compilation.  In both cases
-		// skip enforcement: the newly generated lock file will embed a manifest that
-		// serves as the baseline for future compilations.
-		safeUpdateLog.Print("No existing manifest found; skipping safe update enforcement (baseline will be created)")
-		return nil
+		// Treat no prior manifest as an empty baseline so that newly introduced
+		// secrets and actions are flagged on first compilation as well.
+		safeUpdateLog.Print("No existing manifest found; enforcing safe update with empty baseline (new secrets/actions will be flagged)")
+		manifest = &GHAWManifest{}
 	}
 
 	secretViolations := collectSecretViolations(manifest, secretNames)

--- a/pkg/workflow/safe_update_enforcement_test.go
+++ b/pkg/workflow/safe_update_enforcement_test.go
@@ -19,18 +19,20 @@ func TestEnforceSafeUpdate(t *testing.T) {
 		wantErrMsgs []string
 	}{
 		{
-			name:        "nil manifest (no lock file) skips enforcement on first compile",
+			name:        "nil manifest (no lock file) enforces on first compile — new secret flagged",
 			manifest:    nil,
 			secretNames: []string{"MY_SECRET"},
 			actionRefs:  []string{},
-			wantErr:     false,
+			wantErr:     true,
+			wantErrMsgs: []string{"MY_SECRET", "safe update mode"},
 		},
 		{
-			name:        "nil manifest (no lock file) skips enforcement for custom actions",
+			name:        "nil manifest (no lock file) enforces on first compile — custom action flagged",
 			manifest:    nil,
 			secretNames: []string{},
 			actionRefs:  []string{"my-org/my-action@abc1234 # v1"},
-			wantErr:     false,
+			wantErr:     true,
+			wantErrMsgs: []string{"my-org/my-action", "safe update mode"},
 		},
 		{
 			name:        "nil manifest (no lock file) allows GITHUB_TOKEN on first compile",

--- a/pkg/workflow/safe_update_enforcement_test.go
+++ b/pkg/workflow/safe_update_enforcement_test.go
@@ -19,20 +19,18 @@ func TestEnforceSafeUpdate(t *testing.T) {
 		wantErrMsgs []string
 	}{
 		{
-			name:        "nil manifest (no lock file) blocks secrets on first compile",
+			name:        "nil manifest (no lock file) skips enforcement on first compile",
 			manifest:    nil,
 			secretNames: []string{"MY_SECRET"},
 			actionRefs:  []string{},
-			wantErr:     true,
-			wantErrMsgs: []string{"MY_SECRET", "safe update mode"},
+			wantErr:     false,
 		},
 		{
-			name:        "nil manifest (no lock file) blocks custom actions on first compile",
+			name:        "nil manifest (no lock file) skips enforcement for custom actions",
 			manifest:    nil,
 			secretNames: []string{},
 			actionRefs:  []string{"my-org/my-action@abc1234 # v1"},
-			wantErr:     true,
-			wantErrMsgs: []string{"my-org/my-action", "safe update mode"},
+			wantErr:     false,
 		},
 		{
 			name:        "nil manifest (no lock file) allows GITHUB_TOKEN on first compile",
@@ -291,7 +289,7 @@ func TestBuildSafeUpdateError(t *testing.T) {
 		assert.Contains(t, msg, "safe update mode", "error message")
 		assert.Contains(t, msg, "NEW_SECRET", "violation in message")
 		assert.Contains(t, msg, "ANOTHER_SECRET", "violation in message")
-		assert.Contains(t, msg, "interactive agentic flow", "remediation guidance")
+		assert.Contains(t, msg, "--approve", "remediation guidance")
 	})
 
 	t.Run("added actions only", func(t *testing.T) {
@@ -433,48 +431,53 @@ func TestCollectActionViolations(t *testing.T) {
 }
 
 func TestEffectiveSafeUpdate(t *testing.T) {
-	// effectiveSafeUpdate is equivalent to effectiveStrictMode:
-	// it returns true when the compiler safeUpdate flag is set, OR when strict
-	// mode is active (which defaults to true unless frontmatter sets strict: false).
+	// effectiveSafeUpdate returns true when strict mode is active (default true),
+	// UNLESS the compiler approve flag is set, which skips enforcement entirely.
 	tests := []struct {
 		name           string
-		compilerFlag   bool
+		approveFlag    bool
 		rawFrontmatter map[string]any
 		want           bool
 	}{
 		{
-			name:         "compiler flag off, no frontmatter => true (strict default)",
-			compilerFlag: false,
-			want:         true, // strict mode defaults to true, so safe update is enabled
+			name:        "approve off, no frontmatter => true (strict default)",
+			approveFlag: false,
+			want:        true, // strict mode defaults to true, so safe update is enabled
 		},
 		{
-			name:         "compiler flag on => true",
-			compilerFlag: true,
-			want:         true,
+			name:        "approve on => false (enforcement skipped)",
+			approveFlag: true,
+			want:        false,
 		},
 		{
-			name:           "frontmatter strict: false, compiler flag off => false",
-			compilerFlag:   false,
+			name:           "frontmatter strict: false, approve off => false",
+			approveFlag:    false,
 			rawFrontmatter: map[string]any{"strict": false},
 			want:           false,
 		},
 		{
-			name:           "frontmatter strict: false, compiler flag on => true",
-			compilerFlag:   true,
+			name:           "frontmatter strict: false, approve on => false",
+			approveFlag:    true,
 			rawFrontmatter: map[string]any{"strict": false},
-			want:           true, // CLI flag overrides frontmatter
+			want:           false,
 		},
 		{
-			name:           "frontmatter strict: true, compiler flag off => true",
-			compilerFlag:   false,
+			name:           "frontmatter strict: true, approve off => true",
+			approveFlag:    false,
 			rawFrontmatter: map[string]any{"strict": true},
 			want:           true,
+		},
+		{
+			name:           "frontmatter strict: true, approve on => false (flag overrides)",
+			approveFlag:    true,
+			rawFrontmatter: map[string]any{"strict": true},
+			want:           false, // --approve overrides strict mode
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Compiler{safeUpdate: tt.compilerFlag}
+			c := &Compiler{approve: tt.approveFlag}
 			data := &WorkflowData{RawFrontmatter: tt.rawFrontmatter}
 			got := c.effectiveSafeUpdate(data)
 			assert.Equal(t, tt.want, got, "effectiveSafeUpdate result")

--- a/pkg/workflow/safe_update_enforcement_test.go
+++ b/pkg/workflow/safe_update_enforcement_test.go
@@ -291,7 +291,7 @@ func TestBuildSafeUpdateError(t *testing.T) {
 		assert.Contains(t, msg, "safe update mode", "error message")
 		assert.Contains(t, msg, "NEW_SECRET", "violation in message")
 		assert.Contains(t, msg, "ANOTHER_SECRET", "violation in message")
-		assert.Contains(t, msg, "--approve", "remediation guidance")
+		assert.Contains(t, msg, "--approve-updates", "remediation guidance")
 	})
 
 	t.Run("added actions only", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #26155

Resolves the confusing UX around `--safe-update` and `--strict` flags by:

### Changes

1. **Renamed `--safe-update` to `--approve`** with inverted semantics:
   - `--approve` now **skips** safe update enforcement (approves all changes)
   - Previously `--safe-update` confusingly **force-enabled** enforcement, which was already on by default via strict mode

2. **Skip enforcement when no prior manifest exists**: When a lock file was compiled before the safe updates feature (no `gh-aw-manifest` comment), or on first compilation (no lock file at all), enforcement is now skipped silently. The newly generated lock file creates the baseline manifest for future compilations.

3. **Updated remediation message** to lead with the actionable `--approve` flag:
   ```
   Remediation options:
     1. Use the --approve flag to allow the changes.
     2. Revert the unapproved changes.
     3. Use an interactive coding agent to review and approve the changes.
   ```

4. **Added `--approve` flag to all compilation paths**: `compile`, `run`, and `upgrade` commands

### Testing

- Updated all unit tests for `EnforceSafeUpdate`, `effectiveSafeUpdate`, and `buildSafeUpdateError`
- Updated all integration tests for first-compile and recompile scenarios
- Updated `collectWorkflowFiles` and `recompileWorkflow` signatures and test call sites

---

---
✨ PR Review Safe Output Test - Run 24408518985

> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 2 items</summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - github/gh-aw#26231 `pull_request_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - github/gh-aw#26229 `pull_request_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> 💥 *[THE END] — Illustrated by [Smoke Claude](https://github.com/github/gh-aw/actions/runs/24408518985)* · ● 362.4K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fsmoke-claude%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Smoke Claude, engine: claude, model: auto, id: 24408518985, workflow_id: smoke-claude, run: https://github.com/github/gh-aw/actions/runs/24408518985 -->