### PR TITLE
feat: add dependabot repair workflow

### DIFF
--- a/.github/workflows/dependabot-repair.yml
+++ b/.github/workflows/dependabot-repair.yml
@@ -1,11 +1,11 @@
 name: Dependabot Repair
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:
   dependabot-repair:
     if: github.actor == 'dependabot[bot]'
-    uses: githubnext/dependabot-campaign/.github/workflows/dependabot-repair-reusable.lock.yml@v0.2.0
+    uses: githubnext/dependabot-campaign/.github/workflows/dependabot-repair-reusable.lock.yml@ff91842c074b23270d3a0e26a7206a251232a374 # v0.2.0
     secrets: inherit

--- a/.github/workflows/dependabot-repair.yml
+++ b/.github/workflows/dependabot-repair.yml
@@ -1,0 +1,11 @@
+name: Dependabot Repair
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  dependabot-repair:
+    if: github.actor == 'dependabot[bot]'
+    uses: githubnext/dependabot-campaign/.github/workflows/dependabot-repair-reusable.lock.yml@v0.2.0
+    secrets: inherit


### PR DESCRIPTION
- Adds new GitHub Actions workflow to automate repairs for pull requests created by Dependabot.
- The workflow triggers on pull request events and leverages a reusable workflow (Dependabot campaign) from an external repository.