### PR TITLE
fix: wait up to 6h for run completion in repeated workflow runs

### DIFF
--- a/pkg/cli/run_workflow_execution.go
+++ b/pkg/cli/run_workflow_execution.go
@@ -22,6 +22,9 @@ import (
 
 var executionLog = logger.New("cli:run_workflow_execution")
 
+// workflowCompletionWaitTimeoutMinutes matches the GitHub Actions maximum job runtime.
+const workflowCompletionWaitTimeoutMinutes = 6 * 60
+
 // RunOptions contains all configuration options for running workflows
 type RunOptions struct {
 	Enable            bool     // Enable the workflow if it's disabled
@@ -461,7 +464,7 @@ func RunWorkflowOnGitHub(ctx context.Context, workflowIdOrName string, opts RunO
 				}
 
 				runIDStr := strconv.FormatInt(runInfo.DatabaseID, 10)
-				if err := WaitForWorkflowCompletion(ctx, targetRepo, runIDStr, 30, opts.Verbose); err != nil {
+				if err := WaitForWorkflowCompletion(ctx, targetRepo, runIDStr, workflowCompletionWaitTimeoutMinutes, opts.Verbose); err != nil {
 					// Propagate interrupts/cancellation so the caller (repeat loop) can stop
 					if ctx.Err() != nil || errors.Is(err, ErrInterrupted) {
 						return err


### PR DESCRIPTION
## Summary
- replace the hardcoded 30-minute wait in `gh aw run` workflow completion polling
- use a named constant set to 6 hours (GitHub Actions max runtime)
- prevents false timeout warnings when `--repeat` workflows exceed 30 minutes

## Problem
`gh aw run ... --repeat 5` could emit:
- Waiting for workflow completion...
- Workflow did not complete successfully: operation timed out after 30m0s
- Successfully triggered 1 workflow(s)

for workflows that are still legitimately running.

## Fix
Use a 6-hour wait timeout when waiting for run completion in the run execution path.

## Validation
- Focused tests were run before PR creation:
  - `go test -v -run "TestRunWorkflowOnGitHub_InputValidation|TestRunWorkflowsOnGitHub_InputValidation|TestWaitForWorkflowCompletion_Timeout|TestWaitForWorkflowCompletion_ContextCancellation" ./pkg/cli/`
- Full `make agent-finish` validation is pending and will be run next per request.
