### PR TITLE
[FAQ] Update: off-platform admission control for safe outputs

### DIFF
--- a/docs/src/content/docs/reference/faq.md
+++ b/docs/src/content/docs/reference/faq.md
@@ -242,6 +242,30 @@ This approval is enforced by GitHub's infrastructure, not by workflow logic the 
 
 Note that the *policy* — which environments require approval, what safe outputs are configured — is defined by whoever controls the repository. The admission decision for each run can be external; the admission policy itself is internal to repository owners.
 
+**Fully off-platform admission control**
+
+If your threat model requires an authority completely outside GitHub's control plane — such as an external policy engine, a PAM/PIM system, or a compliance approval workflow — call that system from your gate job before it proceeds:
+
+```yaml wrap
+jobs:
+  external-admission:
+    runs-on: ubuntu-latest
+    environment: production-deploy   # optional: also adds GitHub-native reviewer gate
+    steps:
+      - name: Request admission from external authority
+        run: |
+          curl --fail -X POST https://YOUR_POLICY_ENGINE/v1/admit \
+            -H "Authorization: Bearer $POLICY_TOKEN" \
+            -d '{"workflow_run": "${{ github.run_id }}"}'
+        env:
+          POLICY_TOKEN: ${{ secrets.POLICY_TOKEN }}
+
+safe-outputs:
+  needs: [external-admission]   # write jobs don't run until external admission is granted
+```
+
+If the external call fails or is denied, the safe output jobs never run. This places the final admission decision in a system entirely independent of GitHub.
+
 ### How is my code and data processed?
 
 By default, your workflow is run on GitHub Actions, like any other GitHub Actions workflow, and as one if its jobs it invokes your nominated [AI Engine (coding agent)](/gh-aw/reference/engines/), run in a container. This engine may in turn make tool calls and MCP calls. When using the default **GitHub Copilot CLI**, the workflow is processed by the `copilot` CLI tool which uses GitHub Copilot's services and related AI models. The specifics depend on your engine choice:

--- a/docs/src/content/docs/reference/faq.md
+++ b/docs/src/content/docs/reference/faq.md
@@ -250,6 +250,7 @@ If your threat model requires an authority completely outside GitHub's control p
 jobs:
   external-admission:
     runs-on: ubuntu-latest
+    needs: [agent, detection]        # waits for agent output and threat scanning to complete
     environment: production-deploy   # optional: also adds GitHub-native reviewer gate
     steps:
       - name: Request admission from external authority


### PR DESCRIPTION
Extends the existing FAQ entry "Can I require external human approval before safe outputs are applied?" to cover fully off-platform admission control — i.e., calling an external policy engine, PAM/PIM system, or compliance approval API from the gate job before safe output jobs are allowed to run.

The previous entry covered GitHub-hosted Environment protection rules. This adds a concrete example for users whose threat model requires an authority entirely outside GitHub's control plane.

**Change type:** Update to existing entry (no new section added)

**Source issue:** github/agentic-workflows#517




> Generated by [Feedback Question Answerer](https://github.com/github/agentic-workflows/actions/runs/25213511491/agentic_workflow) for issue #517 · ● 585.4K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-id%3A+feedback-question-answerer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Feedback Question Answerer, engine: copilot, version: 1.0.35, model: auto, id: 25213511491, workflow_id: feedback-question-answerer, run: https://github.com/github/agentic-workflows/actions/runs/25213511491 -->

<!-- gh-aw-workflow-id: feedback-question-answerer -->