### PR TITLE
Remove cache option from Go setup step

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -28,7 +28,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
       with:
-        cache: true
         go-version-file: go.mod
     - name: Install npm dependencies
       run: cd actions/setup/js && npm ci


### PR DESCRIPTION
Removed caching for Go setup in GitHub Actions workflow.