### PR TITLE
docs: add runner environment requirements, GHES, and ARC sections to self-hosted guide

### DIFF
--- a/docs/src/content/docs/guides/self-hosted-runners.md
+++ b/docs/src/content/docs/guides/self-hosted-runners.md
@@ -1,6 +1,6 @@
 ---
 title: Self-Hosted Runners
-description: How to configure the runs-on field to target self-hosted runners in agentic workflows.
+description: How to configure and run agentic workflows on self-hosted runners, ARC/Kubernetes, and GHES environments.
 ---
 
 Use the `runs-on` frontmatter field to target a self-hosted runner instead of the default `ubuntu-latest`.
@@ -152,3 +152,105 @@ This setting applies to every job in `agentics-maintenance.yml` (close-expired-e
 - [Network Access](/gh-aw/reference/network/) — configuring outbound network permissions
 - [Sandbox](/gh-aw/reference/sandbox/) — container and Docker requirements
 - [Ephemerals](/gh-aw/guides/ephemerals/#maintenance-configuration) — full `aw.json` maintenance configuration reference
+- [Enterprise Configuration](/gh-aw/enterprise-configuration/) — custom API endpoints for GHEC/GHES
+
+## Runner environment requirements
+
+Self-hosted runners must meet these requirements for agentic workflows to run reliably.
+
+### Docker
+
+A working Docker daemon is required. The MCP gateway and sandbox run as containers.
+
+- **Unix socket**: Docker must be accessible via a Unix socket (typically `/var/run/docker.sock`). The gateway resolves the socket path from `DOCKER_HOST` if set.
+- **Docker group**: The runner user must be in the `docker` group, or the socket must be world-readable.
+- **ARC/Kubernetes**: If using [actions-runner-controller](https://github.com/actions/actions-runner-controller) with Docker-in-Docker (dind), the dind sidecar must share the Docker socket via an `emptyDir` volume. The gateway will retry the socket check for up to 10 seconds to handle startup race conditions.
+
+### Filesystem
+
+- **Use `RUNNER_TEMP` for transient state.** All job-scoped temporary files (sandbox state, tool downloads, intermediate outputs) should go to `$RUNNER_TEMP`, which is cleaned between jobs. Never write to `/tmp` on shared runners — it persists across jobs.
+- **No root or sudo assumption.** The runner user may not have root or `sudo` access (except for the initial iptables setup, which requires `sudo`). Tool installs, file operations, and sandbox setup should work as the unprivileged runner user.
+- **No global installs.** Do not install packages to `/usr/local/`, `/opt/hostedtoolcache/`, or other system-wide paths. These may be read-only, shared across runners, or bind-mounted read-only inside the sandbox. Use job-scoped writable locations instead.
+- **No hardcoded `HOME` paths.** The runner's home directory may not be `/home/runner`. Use `$HOME` or `$RUNNER_TEMP` instead of hardcoded paths.
+
+### Post-job cleanup
+
+Self-hosted runners persist between jobs. Agentic workflows should clean up after themselves:
+
+- Files written to `$RUNNER_TEMP` are automatically cleaned.
+- Docker containers on the `awf-net` bridge are stopped and removed by the sandbox teardown.
+- If your workflow creates files outside `$RUNNER_TEMP` (e.g. in `$GITHUB_WORKSPACE`), the runner's built-in workspace cleanup handles this.
+
+### Network
+
+Self-hosted runners need outbound HTTPS access to:
+
+- `api.githubcopilot.com` (or your enterprise Copilot endpoint)
+- `github.com` (or your GHES instance)
+- `ghcr.io` (to pull the MCP gateway container image)
+- Any domains listed in your workflow's `network.allowed` configuration
+
+## GHES (GitHub Enterprise Server)
+
+Agentic workflows can run on GHES with some additional configuration.
+
+### Artifact compatibility
+
+GHES does not support the `@actions/artifact` v2.0.0+ backend used by `upload-artifact@v4+` and `download-artifact@v4+`. Compiled workflows use the latest artifact action versions by default, which fail on GHES with `GHESNotSupportedError`.
+
+Enable the `ghes-artifact-compat` feature flag to use compatible v3.x artifact actions:
+
+```aw
+---
+on: workflow_dispatch
+runs-on: [self-hosted, linux]
+features:
+  ghes-artifact-compat: true
+engine: copilot
+---
+```
+
+Or set the environment variable globally:
+
+```bash
+GH_AW_FEATURES=ghes-artifact-compat gh aw compile
+```
+
+This makes the compiler emit `upload-artifact@v3.2.2` and `download-artifact@v3.1.0` instead of the latest versions, which are compatible with all GHES versions.
+
+### API endpoint
+
+GHES instances need the `api-target` engine configuration. See [Enterprise Configuration](/gh-aw/enterprise-configuration/) for full setup instructions.
+
+```aw
+---
+engine:
+  id: copilot
+  api-target: api.enterprise.githubcopilot.com
+network:
+  allowed:
+    - defaults
+    - github.company.com
+    - api.enterprise.githubcopilot.com
+---
+```
+
+## ARC (Actions Runner Controller)
+
+When running on [ARC](https://github.com/actions/actions-runner-controller) with Kubernetes:
+
+### Docker-in-Docker (dind) sidecar
+
+The standard ARC dind pattern with a shared `emptyDir` for the Docker socket is supported. The MCP gateway:
+
+1. Resolves the Docker socket path from `DOCKER_HOST` (supports `unix://` paths and bare absolute paths)
+2. Auto-detects the socket's group ID for correct permissions
+3. Retries the socket check for up to 10 seconds to handle the race condition where the gateway starts before `dockerd`
+
+### Pod security
+
+The runner pod requires `privileged: true` on both the dind sidecar and the runner container. This is needed for:
+
+- `dockerd` in the dind sidecar
+- `iptables` rules for the agentic workflow firewall
+- Chroot/sandbox setup in the runner container

--- a/docs/src/content/docs/guides/self-hosted-runners.md
+++ b/docs/src/content/docs/guides/self-hosted-runners.md
@@ -162,13 +162,13 @@ Self-hosted runners must meet these requirements for agentic workflows to run re
 
 A working Docker daemon is required. The MCP gateway and sandbox run as containers.
 
-- **Unix socket**: Docker must be accessible via a Unix socket (typically `/var/run/docker.sock`). If `DOCKER_HOST` is set, the gateway only treats `unix://...` or bare absolute paths as socket paths; other schemes (for example `tcp://...`) cause the mount path to fall back to `/var/run/docker.sock`.
+- **Unix socket**: Docker must be accessible via a Unix socket (typically `/var/run/docker.sock`). When `DOCKER_HOST` is unset, the gateway mounts `/var/run/docker.sock`. If `DOCKER_HOST` is `unix://...` or a bare absolute path, that socket path is mounted. Other schemes (for example `tcp://...`) are ignored for mounting and fall back to `/var/run/docker.sock`.
 - **Docker group**: The runner user must be in the `docker` group, or the socket must be world-readable.
 - **ARC/Kubernetes**: If using [actions-runner-controller](https://github.com/actions/actions-runner-controller) with Docker-in-Docker (dind), the dind sidecar must share the Docker socket via an `emptyDir` volume. The gateway will retry the socket check for up to 10 seconds to handle startup race conditions.
 
 ### Filesystem
 
-- **Use `RUNNER_TEMP` for transient state.** All job-scoped temporary files (sandbox state, tool downloads, intermediate outputs) should go to `$RUNNER_TEMP`, which is cleaned between jobs. On shared runners, avoid writing arbitrary workflow data to `/tmp` because it can persist across jobs. The `/tmp/gh-aw` prefix is reserved for gh-aw/AWF ARC DinD path rewriting. Ensure your runner cleanup policy removes stale `/tmp/gh-aw` contents between jobs.
+- **Use `RUNNER_TEMP` for transient state.** All job-scoped temporary files (sandbox state, tool downloads, intermediate outputs) should go to `$RUNNER_TEMP`, which is cleaned between jobs. On shared runners, avoid writing arbitrary workflow data to `/tmp` because it can persist across jobs. The `/tmp/gh-aw` prefix is reserved for gh-aw/AWF ARC DinD path rewriting and is reset by `actions/setup` at job start. Keep your normal runner `/tmp` cleanup policy enabled to remove stale data from interrupted jobs.
 - **No root or sudo assumption.** The runner user may not have root or `sudo` access (except for the initial iptables setup, which requires `sudo`). Tool installs, file operations, and sandbox setup should work as the unprivileged runner user.
 - **No global installs.** Do not install packages to `/usr/local/`, `/opt/hostedtoolcache/`, or other system-wide paths. These may be read-only, shared across runners, or bind-mounted read-only inside the sandbox. Use job-scoped writable locations instead.
 - **No hardcoded `HOME` paths.** The runner's home directory may not be `/home/runner`. Use `$HOME` or `$RUNNER_TEMP` instead of hardcoded paths.

--- a/docs/src/content/docs/guides/self-hosted-runners.md
+++ b/docs/src/content/docs/guides/self-hosted-runners.md
@@ -162,13 +162,13 @@ Self-hosted runners must meet these requirements for agentic workflows to run re
 
 A working Docker daemon is required. The MCP gateway and sandbox run as containers.
 
-- **Unix socket**: Docker must be accessible via a Unix socket (typically `/var/run/docker.sock`). If `DOCKER_HOST` is set, the gateway only treats `unix://...` or bare absolute paths as socket paths; other schemes (for example `tcp://...`) are not used for the mount and fall back to `/var/run/docker.sock`.
+- **Unix socket**: Docker must be accessible via a Unix socket (typically `/var/run/docker.sock`). If `DOCKER_HOST` is set, the gateway only treats `unix://...` or bare absolute paths as socket paths; other schemes (for example `tcp://...`) cause the mount path to fall back to `/var/run/docker.sock`.
 - **Docker group**: The runner user must be in the `docker` group, or the socket must be world-readable.
 - **ARC/Kubernetes**: If using [actions-runner-controller](https://github.com/actions/actions-runner-controller) with Docker-in-Docker (dind), the dind sidecar must share the Docker socket via an `emptyDir` volume. The gateway will retry the socket check for up to 10 seconds to handle startup race conditions.
 
 ### Filesystem
 
-- **Use `RUNNER_TEMP` for transient state.** All job-scoped temporary files (sandbox state, tool downloads, intermediate outputs) should go to `$RUNNER_TEMP`, which is cleaned between jobs. On shared runners, avoid writing arbitrary workflow data to `/tmp` because it can persist across jobs. The `/tmp/gh-aw` prefix is reserved for gh-aw/AWF ARC DinD path rewriting; ensure your runner cleanup policy removes stale `/tmp/gh-aw` contents between jobs.
+- **Use `RUNNER_TEMP` for transient state.** All job-scoped temporary files (sandbox state, tool downloads, intermediate outputs) should go to `$RUNNER_TEMP`, which is cleaned between jobs. On shared runners, avoid writing arbitrary workflow data to `/tmp` because it can persist across jobs. The `/tmp/gh-aw` prefix is reserved for gh-aw/AWF ARC DinD path rewriting. Ensure your runner cleanup policy removes stale `/tmp/gh-aw` contents between jobs.
 - **No root or sudo assumption.** The runner user may not have root or `sudo` access (except for the initial iptables setup, which requires `sudo`). Tool installs, file operations, and sandbox setup should work as the unprivileged runner user.
 - **No global installs.** Do not install packages to `/usr/local/`, `/opt/hostedtoolcache/`, or other system-wide paths. These may be read-only, shared across runners, or bind-mounted read-only inside the sandbox. Use job-scoped writable locations instead.
 - **No hardcoded `HOME` paths.** The runner's home directory may not be `/home/runner`. Use `$HOME` or `$RUNNER_TEMP` instead of hardcoded paths.

--- a/docs/src/content/docs/guides/self-hosted-runners.md
+++ b/docs/src/content/docs/guides/self-hosted-runners.md
@@ -162,13 +162,13 @@ Self-hosted runners must meet these requirements for agentic workflows to run re
 
 A working Docker daemon is required. The MCP gateway and sandbox run as containers.
 
-- **Unix socket**: Docker must be accessible via a Unix socket (typically `/var/run/docker.sock`). If `DOCKER_HOST` is set, the gateway only treats `unix://...` or bare absolute paths as socket paths; other schemes (for example `tcp://...`) fall back to `/var/run/docker.sock`.
+- **Unix socket**: Docker must be accessible via a Unix socket (typically `/var/run/docker.sock`). If `DOCKER_HOST` is set, the gateway only treats `unix://...` or bare absolute paths as socket paths; other schemes (for example `tcp://...`) are not used for the mount and fall back to `/var/run/docker.sock`.
 - **Docker group**: The runner user must be in the `docker` group, or the socket must be world-readable.
 - **ARC/Kubernetes**: If using [actions-runner-controller](https://github.com/actions/actions-runner-controller) with Docker-in-Docker (dind), the dind sidecar must share the Docker socket via an `emptyDir` volume. The gateway will retry the socket check for up to 10 seconds to handle startup race conditions.
 
 ### Filesystem
 
-- **Use `RUNNER_TEMP` for transient state.** All job-scoped temporary files (sandbox state, tool downloads, intermediate outputs) should go to `$RUNNER_TEMP`, which is cleaned between jobs. On shared runners, avoid writing arbitrary workflow data to `/tmp` because it can persist across jobs. The `/tmp/gh-aw` prefix is reserved for gh-aw/AWF ARC DinD path rewriting and should be cleaned by runner maintenance between jobs.
+- **Use `RUNNER_TEMP` for transient state.** All job-scoped temporary files (sandbox state, tool downloads, intermediate outputs) should go to `$RUNNER_TEMP`, which is cleaned between jobs. On shared runners, avoid writing arbitrary workflow data to `/tmp` because it can persist across jobs. The `/tmp/gh-aw` prefix is reserved for gh-aw/AWF ARC DinD path rewriting; ensure your runner cleanup policy removes stale `/tmp/gh-aw` contents between jobs.
 - **No root or sudo assumption.** The runner user may not have root or `sudo` access (except for the initial iptables setup, which requires `sudo`). Tool installs, file operations, and sandbox setup should work as the unprivileged runner user.
 - **No global installs.** Do not install packages to `/usr/local/`, `/opt/hostedtoolcache/`, or other system-wide paths. These may be read-only, shared across runners, or bind-mounted read-only inside the sandbox. Use job-scoped writable locations instead.
 - **No hardcoded `HOME` paths.** The runner's home directory may not be `/home/runner`. Use `$HOME` or `$RUNNER_TEMP` instead of hardcoded paths.

--- a/docs/src/content/docs/guides/self-hosted-runners.md
+++ b/docs/src/content/docs/guides/self-hosted-runners.md
@@ -162,13 +162,13 @@ Self-hosted runners must meet these requirements for agentic workflows to run re
 
 A working Docker daemon is required. The MCP gateway and sandbox run as containers.
 
-- **Unix socket**: Docker must be accessible via a Unix socket (typically `/var/run/docker.sock`). When `DOCKER_HOST` is unset, the gateway mounts `/var/run/docker.sock`. If `DOCKER_HOST` is `unix://...` or a bare absolute path, that socket path is mounted. Other schemes (for example `tcp://...`) are ignored for mounting and fall back to `/var/run/docker.sock`.
+- **Unix socket**: Docker must be accessible via a Unix socket (typically `/var/run/docker.sock`). If `DOCKER_HOST` is unset, the gateway mounts `/var/run/docker.sock`. If `DOCKER_HOST` is `unix://...` or a bare absolute path, the gateway mounts that socket path. Other schemes (for example `tcp://...`) are ignored for mounts and default back to `/var/run/docker.sock`.
 - **Docker group**: The runner user must be in the `docker` group, or the socket must be world-readable.
 - **ARC/Kubernetes**: If using [actions-runner-controller](https://github.com/actions/actions-runner-controller) with Docker-in-Docker (dind), the dind sidecar must share the Docker socket via an `emptyDir` volume. The gateway will retry the socket check for up to 10 seconds to handle startup race conditions.
 
 ### Filesystem
 
-- **Use `RUNNER_TEMP` for transient state.** All job-scoped temporary files (sandbox state, tool downloads, intermediate outputs) should go to `$RUNNER_TEMP`, which is cleaned between jobs. On shared runners, avoid writing arbitrary workflow data to `/tmp` because it can persist across jobs. The `/tmp/gh-aw` prefix is reserved for gh-aw/AWF ARC DinD path rewriting and is reset by `actions/setup` at job start. Keep your normal runner `/tmp` cleanup policy enabled to remove stale data from interrupted jobs.
+- **Use `RUNNER_TEMP` for transient state.** Put sandbox state, tool downloads, and intermediate outputs in `$RUNNER_TEMP`, which is cleaned between jobs. On shared runners, avoid writing arbitrary workflow data to `/tmp` because it can persist across jobs. The `/tmp/gh-aw` prefix is reserved for gh-aw/AWF ARC DinD path rewriting. `actions/setup` resets `/tmp/gh-aw` at job start, and your normal runner `/tmp` cleanup policy should handle stale data from interrupted jobs.
 - **No root or sudo assumption.** The runner user may not have root or `sudo` access (except for the initial iptables setup, which requires `sudo`). Tool installs, file operations, and sandbox setup should work as the unprivileged runner user.
 - **No global installs.** Do not install packages to `/usr/local/`, `/opt/hostedtoolcache/`, or other system-wide paths. These may be read-only, shared across runners, or bind-mounted read-only inside the sandbox. Use job-scoped writable locations instead.
 - **No hardcoded `HOME` paths.** The runner's home directory may not be `/home/runner`. Use `$HOME` or `$RUNNER_TEMP` instead of hardcoded paths.

--- a/docs/src/content/docs/guides/self-hosted-runners.md
+++ b/docs/src/content/docs/guides/self-hosted-runners.md
@@ -152,7 +152,7 @@ This setting applies to every job in `agentics-maintenance.yml` (close-expired-e
 - [Network Access](/gh-aw/reference/network/) — configuring outbound network permissions
 - [Sandbox](/gh-aw/reference/sandbox/) — container and Docker requirements
 - [Ephemerals](/gh-aw/guides/ephemerals/#maintenance-configuration) — full `aw.json` maintenance configuration reference
-- [Enterprise Configuration](/gh-aw/enterprise-configuration/) — custom API endpoints for GHEC/GHES
+- [Enterprise Configuration](/gh-aw/reference/enterprise-configuration/) — custom API endpoints for GHEC/GHES
 
 ## Runner environment requirements
 
@@ -162,13 +162,13 @@ Self-hosted runners must meet these requirements for agentic workflows to run re
 
 A working Docker daemon is required. The MCP gateway and sandbox run as containers.
 
-- **Unix socket**: Docker must be accessible via a Unix socket (typically `/var/run/docker.sock`). The gateway resolves the socket path from `DOCKER_HOST` if set.
+- **Unix socket**: Docker must be accessible via a Unix socket (typically `/var/run/docker.sock`). If `DOCKER_HOST` is set, the gateway only treats `unix://...` or bare absolute paths as socket paths; other schemes (for example `tcp://...`) fall back to `/var/run/docker.sock`.
 - **Docker group**: The runner user must be in the `docker` group, or the socket must be world-readable.
 - **ARC/Kubernetes**: If using [actions-runner-controller](https://github.com/actions/actions-runner-controller) with Docker-in-Docker (dind), the dind sidecar must share the Docker socket via an `emptyDir` volume. The gateway will retry the socket check for up to 10 seconds to handle startup race conditions.
 
 ### Filesystem
 
-- **Use `RUNNER_TEMP` for transient state.** All job-scoped temporary files (sandbox state, tool downloads, intermediate outputs) should go to `$RUNNER_TEMP`, which is cleaned between jobs. Never write to `/tmp` on shared runners — it persists across jobs.
+- **Use `RUNNER_TEMP` for transient state.** All job-scoped temporary files (sandbox state, tool downloads, intermediate outputs) should go to `$RUNNER_TEMP`, which is cleaned between jobs. On shared runners, avoid writing arbitrary workflow data to `/tmp` because it can persist across jobs. The `/tmp/gh-aw` prefix is reserved for gh-aw/AWF ARC DinD path rewriting and should be cleaned by runner maintenance between jobs.
 - **No root or sudo assumption.** The runner user may not have root or `sudo` access (except for the initial iptables setup, which requires `sudo`). Tool installs, file operations, and sandbox setup should work as the unprivileged runner user.
 - **No global installs.** Do not install packages to `/usr/local/`, `/opt/hostedtoolcache/`, or other system-wide paths. These may be read-only, shared across runners, or bind-mounted read-only inside the sandbox. Use job-scoped writable locations instead.
 - **No hardcoded `HOME` paths.** The runner's home directory may not be `/home/runner`. Use `$HOME` or `$RUNNER_TEMP` instead of hardcoded paths.
@@ -198,29 +198,25 @@ Agentic workflows can run on GHES with some additional configuration.
 
 GHES does not support the `@actions/artifact` v2.0.0+ backend used by `upload-artifact@v4+` and `download-artifact@v4+`. Compiled workflows use the latest artifact action versions by default, which fail on GHES with `GHESNotSupportedError`.
 
-Enable the `ghes-artifact-compat` feature flag to use compatible v3.x artifact actions:
+Enable GHES compatibility mode in `.github/workflows/aw.json` to use compatible v3.x artifact actions:
 
-```aw
----
-on: workflow_dispatch
-runs-on: [self-hosted, linux]
-features:
-  ghes-artifact-compat: true
-engine: copilot
----
+```json
+{
+  "ghes": true
+}
 ```
 
-Or set the environment variable globally:
+Or compile with `--ghes` for one-off workflow generation:
 
 ```bash
-GH_AW_FEATURES=ghes-artifact-compat gh aw compile
+gh aw compile --ghes my-workflow.md
 ```
 
 This makes the compiler emit `upload-artifact@v3.2.2` and `download-artifact@v3.1.0` instead of the latest versions, which are compatible with all GHES versions.
 
 ### API endpoint
 
-GHES instances need the `api-target` engine configuration. See [Enterprise Configuration](/gh-aw/enterprise-configuration/) for full setup instructions.
+GHES instances need the `api-target` engine configuration. See [Enterprise Configuration](/gh-aw/reference/enterprise-configuration/) for full setup instructions.
 
 ```aw
 ---


### PR DESCRIPTION
Expands the self-hosted runners guide with three new sections:

- **Runner environment requirements** — guiding principles for filesystem, Docker, cleanup, and network
- **GHES** — artifact compatibility feature flag and API endpoint configuration
- **ARC** — Docker-in-Docker sidecar support and pod security requirements

Ref #28888, #29551